### PR TITLE
Upgrade to support ArrayPartition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproxManifoldProducts"
 uuid = "9bbbb610-88a1-53cd-9763-118ce10c1f89"
 keywords = ["MM-iSAMv2", "SLAM", "inference", "sum-product", "belief-propagation", "nonparametric", "manifolds", "functional"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -21,6 +21,7 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/src/ApproxManifoldProducts.jl
+++ b/src/ApproxManifoldProducts.jl
@@ -7,6 +7,9 @@ using Random
 
 import ManifoldsBase
 import ManifoldsBase: AbstractManifold
+using RecursiveArrayTools: ArrayPartition
+export ArrayPartition
+
 const MB = ManifoldsBase
 using Manifolds
 

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -97,7 +97,7 @@ function setPointPartial!(Mdest::AbstractManifold,
   return dest 
 end
 
-
+#TODO  ArrayPartition should work for now as it's an AbstractVector, but it won't remain mutable
 setPointsMani!(dest::AbstractVector, src::AbstractVector) = (dest .= src)
 setPointsMani!(dest::AbstractMatrix, src::AbstractMatrix) = (dest .= src)
 function setPointsMani!(dest::AbstractVector, src::AbstractMatrix)

--- a/src/services/ManifoldPartials.jl
+++ b/src/services/ManifoldPartials.jl
@@ -2,7 +2,7 @@
 export getManifoldPartial
 
 # forcing ProductManifold to use ArrayPartition as accompanying representation
-const _PartiableRepresentationProduct = Union{Nothing,<:ArrayPartition}
+const _PartiableRepresentationProduct = Union{Nothing,<:ArrayPartition, <:ProductRepr}
 # forcing ProductManifold to use ArrayPartition as accompanying representation
 const _PartiableRepresentationFlat{T} = Union{Nothing,<:AbstractVector{T}}
 # More general representation for Manifold Factors or Groups

--- a/src/services/ManifoldPartials.jl
+++ b/src/services/ManifoldPartials.jl
@@ -1,9 +1,9 @@
 
 export getManifoldPartial
 
-# forcing ProductManifold to use ProductRepr as accompanying representation
-const _PartiableRepresentationProduct = Union{Nothing,<:ProductRepr}
-# forcing ProductManifold to use ProductRepr as accompanying representation
+# forcing ProductManifold to use ArrayPartition as accompanying representation
+const _PartiableRepresentationProduct = Union{Nothing,<:ArrayPartition}
+# forcing ProductManifold to use ArrayPartition as accompanying representation
 const _PartiableRepresentationFlat{T} = Union{Nothing,<:AbstractVector{T}}
 # More general representation for Manifold Factors or Groups
 const _PartiableRepresentation = Union{<:_PartiableRepresentationProduct,<:_PartiableRepresentationFlat,<:AbstractMatrix}
@@ -134,7 +134,7 @@ M_x, _ = getManifoldPartial(M,[1;])
 # returns a new TranslationGroup(1) corresponding to just x dimension
 
 # representation is semidirect product of translation and rotation matrix
-u0 = ProductRepr([0.0;0],[1 0; 0 1.0])
+u0 = ArrayPartition([0.0;0],[1 0; 0 1.0])
 
 # known coordinates are [x,y,θ], eg
 #   vee(M,identity_element(M,u0),log(M,identity_element(M,u0),u0))
@@ -160,7 +160,7 @@ DevNotes
 
 Related
 
-[`getManifold`](@ref), [`AbstractManifold`], [`ProductManifold`], [`GroupManifold`], [`ProductRepr`]
+[`getManifold`](@ref), [`AbstractManifold`], [`ProductManifold`], [`GroupManifold`], [`ArrayPartition`]
 """
 function getManifoldPartial(M::ProductManifold, 
                             partial::AbstractVector{Int}, 
@@ -181,8 +181,9 @@ function getManifoldPartial(M::ProductManifold,
         Mp, = getManifoldPartial(m, partial, nothing, offset, doError=false)
         Mp
       else
-        # hard assumption that repr::ProductRepr to go along with M::ProductManifold
-        Mp, Rp = getManifoldPartial(m, partial, repr.parts[i], offset, doError=false)
+        # hard assumption that repr::ArrayPartition to go along with M::ProductManifold
+        # NOTE submanifold_component is the correct way to avoid this assumption
+        Mp, Rp = getManifoldPartial(m, partial, submanifold_component(repr,i), offset, doError=false)
         push!(ReprArr, Rp)
         Mp
       end
@@ -197,7 +198,7 @@ function getManifoldPartial(M::ProductManifold,
     repr_p = repr === nothing ? nothing : ReprArr[1]
     return (ManiArr[1],repr_p)
   elseif 1 < length(ManiArr)
-    repr_p = repr === nothing ? nothing : ProductRepr(ReprArr...)
+    repr_p = repr === nothing ? nothing : ArrayPartition(ReprArr...)
     return (ProductManifold(ManiArr...), repr_p)
   end
   error("partial manifold calculations should not reach here")

--- a/test/basic_se3.jl
+++ b/test/basic_se3.jl
@@ -18,7 +18,7 @@ using Test
 # c = kde!(c_)
 
 M = SpecialEuclidean(3)
-u0 = ProductRepr(zeros(3),[1 0 0; 0 1 0; 0 0 1.0])
+u0 = ArrayPartition(zeros(3),[1 0 0; 0 1 0; 0 0 1.0])
 ϵ = identity_element(M, u0)
 N = 50
 

--- a/test/testBasicManiProduct.jl
+++ b/test/testBasicManiProduct.jl
@@ -37,7 +37,7 @@ pts = AMP._pointsToMatrixCoords(P12.manifold, pts_)
 ##
 
 M = SpecialEuclidean(2)
-u0 = ProductRepr(zeros(2),[1 0; 0 1.0])
+u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
 ϵ = identity_element(M, u0)
 
 pts1 = [exp(M, ϵ, hat(M, ϵ, [0.05*randn(2);0.75*randn()])) for i in 1:N]

--- a/test/testManiProductBigSmall.jl
+++ b/test/testManiProductBigSmall.jl
@@ -13,7 +13,7 @@ using TensorCast
 
 M = SpecialEuclidean(2)
 N = 100
-u0 = ProductRepr([0;0.0],[1 0; 0 1.0])
+u0 = ArrayPartition([0;0.0],[1 0; 0 1.0])
 ϵ = identity_element(M, u0)
 
 X1 = [exp(M, ϵ, hat(M, ϵ, randn(3))) for i in 1:N]

--- a/test/testManifoldConventions.jl
+++ b/test/testManifoldConventions.jl
@@ -14,10 +14,10 @@ M = SpecialEuclidean(2)
 e0 = identity_element(M)
 
 # body to body next
-bTb_ = ProductRepr([10.0;0], _Rot.RotMatrix(pi/2))
+bTb_ = ArrayPartition([10.0;0], _Rot.RotMatrix(pi/2))
 
 # drive in a clockwise square from the origin
-wTb0 = ProductRepr([100.0;0], _Rot.RotMatrix(0.0))
+wTb0 = ArrayPartition([100.0;0], _Rot.RotMatrix(0.0))
 wTb1 = Manifolds.compose(M, wTb0, bTb_)    # right
 wTb2 = Manifolds.compose(M, wTb1, bTb_)    # top right
 wTb3 = Manifolds.compose(M, wTb2, bTb_)    # top
@@ -43,7 +43,7 @@ wCb4 = vee(M, e0, log(M, e0, wTb4))
 
 
 # Use opposite convention from above to show it is wrong
-wTb0 = ProductRepr([100.0;0], _Rot.RotMatrix(0.0))
+wTb0 = ArrayPartition([100.0;0], _Rot.RotMatrix(0.0))
 wTb1 = Manifolds.compose(M, bTb_, wTb0)    # right
 wTb2 = Manifolds.compose(M, bTb_, wTb1)    # top right
 wTb3 = Manifolds.compose(M, bTb_, wTb2)    # top

--- a/test/testManifoldPartial.jl
+++ b/test/testManifoldPartial.jl
@@ -74,7 +74,7 @@ M = SpecialEuclidean(2)
 @test getManifoldPartial(M, [1;3;])[1] == ProductManifold(TranslationGroup(1), SpecialOrthogonal(2))
 
 
-repr = ProductRepr([0.0; 0], [1 0; 0 1.0])
+repr = ArrayPartition([0.0; 0], [1 0; 0 1.0])
 
 @test getManifoldPartial(M, [1;2;3], repr)[1] == SpecialEuclidean(2)
 @test getManifoldPartial(M, [1;2;3], repr)[2] == repr
@@ -89,13 +89,13 @@ repr = ProductRepr([0.0; 0], [1 0; 0 1.0])
 @test getManifoldPartial(M, [1;2], repr)[2] == [0.0;0]
 
 @test getManifoldPartial(M, [3;], repr)[1] == SpecialOrthogonal(2)
-@test getManifoldPartial(M, [3;], repr)[2] == repr.parts[2]
+@test getManifoldPartial(M, [3;], repr)[2] == submanifold_component(repr,2)
 
 @test getManifoldPartial(M, [1;3;], repr)[1] == ProductManifold(TranslationGroup(1), SpecialOrthogonal(2))
 r_repr = getManifoldPartial(M, [1;3;], repr)[2]
-@test r_repr isa ProductRepr
-@test r_repr.parts[1] == [0.0;]
-@test r_repr.parts[2] == [1 0; 0 1.0]
+@test r_repr isa ArrayPartition
+@test submanifold_component(r_repr,1) == [0.0;]
+@test submanifold_component(r_repr,2) == [1 0; 0 1.0]
 
 ##
 end
@@ -118,7 +118,7 @@ end
 
 N = 100
 M = SpecialEuclidean(2)
-u0 = ProductRepr([0.0; 0], [1 0; 0 1.0])
+u0 = ArrayPartition([0.0; 0], [1 0; 0 1.0])
 
 pts = [exp(M, u0, hat(M, u0, [10 .+ randn(2);randn()])) for i in 1:N]
 

--- a/test/testPartialProductSE2.jl
+++ b/test/testPartialProductSE2.jl
@@ -67,7 +67,7 @@ for sidx = 1:len
 
   u12, = calcProductGaussians(M, [u1,u2], [bw1,bw2]);
 
-  @test isapprox( u12.parts[1], getPoints(p12)[sidx].parts[1] )
+  @test isapprox( submanifold_component(u12,1), submanifold_component(getPoints(p12)[sidx],1))
 end
 
 ## now check the marginal dimensions only
@@ -87,7 +87,7 @@ for sidx = 1:len
 
   u12, = calcProductGaussians(TranslationGroup(2), [u1,u2], [bw1,bw2])
 
-  @test isapprox( u12, getPoints(p12)[sidx].parts[1] )
+  @test isapprox( u12, submanifold_component(getPoints(p12)[sidx],1) )
 end
 
 
@@ -123,9 +123,9 @@ u1 = pts1[selectedLabels__[sidx][1]]
 u2 = pts2[selectedLabels__[sidx][2]]
 
 u12, = calcProductGaussians(M, [u1,u2], [bw1,bw2]);
-u12_, = calcProductGaussians(TranslationGroup(2), [u1.parts[1],u2.parts[1]], [bw1[1:2],bw2[1:2]]);
+u12_, = calcProductGaussians(TranslationGroup(2), [submanifold_component(u1,1),submanifold_component(u2,1)], [bw1[1:2],bw2[1:2]]);
 
-@test isapprox( u12.parts[1], u12_ )
+@test isapprox( submanifold_component(u12,1), u12_ )
 @test isapprox( getPoints(p12__)[sidx], u12_ )
 
 end

--- a/test/testSymmetry.jl
+++ b/test/testSymmetry.jl
@@ -20,8 +20,8 @@ a,b = _Rot.RotMatrix(randn()), _Rot.RotMatrix(randn())
 
 
 M = SpecialEuclidean(2)
-a = ProductRepr(randn(2),_Rot.RotMatrix(randn()))
-b = ProductRepr(randn(2),_Rot.RotMatrix(randn()))
+a = ArrayPartition(randn(2),_Rot.RotMatrix(randn()))
+b = ArrayPartition(randn(2),_Rot.RotMatrix(randn()))
 @test isapprox( distance(M, a, b), distance(M, b, a), atol = 1e-5)
 
 


### PR DESCRIPTION
Ideally, we can support ArrayPartition and ProductRepresentation, however, the use of `identity_element` makes this hard as it currently returns a `ProductReprs` for product groups.

NOTE: the `.parts` use can be replaced by `manifold_component(p, i)`