### PR TITLE
consolidation towards Manifolds.jl cov

### DIFF
--- a/src/CommonUtils.jl
+++ b/src/CommonUtils.jl
@@ -60,15 +60,6 @@ function updateProductSample( dest::BallTreeDensity,
   manikde!(pts, manifolds)
 end
 
-# Returns the covariance (square), not deviation
-function calcCovarianceBasic(M::AbstractManifold, ptsArr::Vector{P}) where P
-  #TODO double check the maths,. it looks like its working at least for groups
-  @warn "use of calcCovarianceBasic should be deprecated or motivated.  Please comment in issue AMP#150.  Also replaces IIF.calcSTDBasicSpread"
-  Σ = cov(M, ptsArr)
-  msst_ = 0 < sum(1e-10 .< msst) ? maximum(msst) : 1.0
-  return msst_
-end
-
 import Statistics: cov
 
 Statistics.cov(mkd::ManifoldKernelDensity) = cov(mkd.manifold, getPoints(mkd))

--- a/src/CommonUtils.jl
+++ b/src/CommonUtils.jl
@@ -69,6 +69,10 @@ function calcCovarianceBasic(M::AbstractManifold, ptsArr::Vector{P}) where P
   return msst_
 end
 
+import Statistics: cov
+
+Statistics.cov(mkd::ManifoldKernelDensity) = cov(mkd.manifold, getPoints(mkd))
+
 """
     $SIGNATURES
 

--- a/src/CommonUtils.jl
+++ b/src/CommonUtils.jl
@@ -60,9 +60,22 @@ function updateProductSample( dest::BallTreeDensity,
   manikde!(pts, manifolds)
 end
 
-import Statistics: cov
+function Statistics.cov(mkd::ManifoldKernelDensity, args...; kwargs...) 
+  cov(mkd.manifold, getPoints(mkd),  args...; kwargs...)
+end
 
-Statistics.cov(mkd::ManifoldKernelDensity) = cov(mkd.manifold, getPoints(mkd))
+function Statistics.mean(mkd::ManifoldKernelDensity, args...; kwargs...)
+  return mean(mkd.manifold, getPoints(mkd), args...; kwargs...)
+end
+
+function Statistics.std(mkd::ManifoldKernelDensity, args...; kwargs...)
+  return std(mkd.manifold, getPoints(mkd), args...; kwargs...)
+end
+
+function Statistics.var(mkd::ManifoldKernelDensity, args...; kwargs...)
+  return var(mkd.manifold, getPoints(mkd), args...; kwargs...)
+end
+
 
 """
     $SIGNATURES

--- a/src/CommonUtils.jl
+++ b/src/CommonUtils.jl
@@ -63,14 +63,8 @@ end
 # Returns the covariance (square), not deviation
 function calcCovarianceBasic(M::AbstractManifold, ptsArr::Vector{P}) where P
   #TODO double check the maths,. it looks like its working at least for groups
-  μ = mean(M, ptsArr)
-  Xcs = vee.(Ref(M), Ref(μ), log.(Ref(M), Ref(μ), ptsArr))
-  Σ = mean(Xcs .* transpose.(Xcs))
-  @debug "calcCovarianceBasic" μ
-  @debug "calcCovarianceBasic" Σ
-  # TODO don't know what to do here so keeping as before, #FIXME it will break
-  # a change between this and previous is that a full covariance matrix is returned
-  msst = Σ
+  @warn "use of calcCovarianceBasic should be deprecated or motivated.  Please comment in issue AMP#150.  Also replaces IIF.calcSTDBasicSpread"
+  Σ = cov(M, ptsArr)
   msst_ = 0 < sum(1e-10 .< msst) ? maximum(msst) : 1.0
   return msst_
 end

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -7,6 +7,17 @@
 @deprecate R(th::Real) _Rot.RotMatrix2(th).mat # = [[cos(th);-sin(th)]';[sin(th);cos(th)]'];
 @deprecate R(;x::Real=0.0,y::Real=0.0,z::Real=0.0) (M=SpecialOrthogonal(3);exp(M,identity_element(M),hat(M,Identity(M),[x,y,z]))) # convert(SO3, so3([x,y,z]))
 
+export calcCovarianceBasic
+# Returns the covariance (square), not deviation
+function calcCovarianceBasic(M::AbstractManifold, ptsArr::Vector{P}) where P
+  @warn "`calcCovarianceBasic` is deprecated. Replace with IIF.calcSTDBasicSpread from IIF or `cov` or `var` from Manifolds. See issue AMP#150."
+  μ = mean(M, ptsArr)
+  Xcs = vee.(Ref(M), Ref(μ), log.(Ref(M), Ref(μ), ptsArr))
+  Σ = mean(Xcs .* transpose.(Xcs))
+  msst = Σ
+  msst_ = 0 < sum(1e-10 .< msst) ? maximum(msst) : 1.0
+  return msst_
+end
 
 ## ======================================================================================================
 ## Remove below before v0.7

--- a/src/ExportAPI.jl
+++ b/src/ExportAPI.jl
@@ -19,7 +19,6 @@ export
   getKDEManifoldBandwidths,
   manifoldProduct,
   manikde!,
-  calcCovarianceBasic,
   isPartial,
   calcProductGaussians
 


### PR DESCRIPTION
Also review and consolidate spread calculations used by IIF.VariableStatistics.jl.

Objective is only have std and cov calculations provided by Manifolds.jl and then wrap or deprecate here in AMP and IIF as usage requires.

The consolidated function ended up in IIF for VariableType dispatches.  Lets upstream as much as we can from IIF to here or Manifolds.jl