### PR TITLE
setPointsMani! of array from point

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -141,6 +141,14 @@ function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{U}, destIdx, 
   end
 end
 
+function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{U}, destIdx) where {T <: AbstractArray, U <: Real}
+  if isbitstype(T)
+    dest[destIdx] = src
+  else
+    setPointsMani!(dest[destIdx], src)
+  end
+end
+
 
 #TODO  ArrayPartition should work for now as it's an AbstractVector, but it won't remain mutable
 setPointsMani!(dest::AbstractVector, src::AbstractVector) = (dest .= src)


### PR DESCRIPTION
`SetPointsMani!` really needs to be refactored. 
Perhaps the design should be: always have a vector of points on a manifold and replace the entire point.
The issue with that will be if the points can no longer efficiently be represented by bits types.