### PR TITLE
Update to LieGroups.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 KernelDensityEstimate = "2472808a-b354-52ea-a80e-1658a3c6056d"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LieGroups = "6774de46-80ba-43f8-ba42-e41071ccfc5f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Manifolds = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
@@ -36,12 +37,19 @@ TransformUtils = "9b8138ad-1b09-5408-aa39-e87ed6d21b63"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[weakdeps]
+Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
+
+[extensions]
+ApproxManiProdGadflyExt = "Gadfly"
+
 [compat]
 Colors = "0.12, 0.13"
 CoordinateTransformations = "0.5, 0.6"
 Distributions = "0.25"
 DocStringExtensions = "0.7, 0.8, 0.9"
 KernelDensityEstimate = "0.5.10"
+LieGroups = "0.1.2"
 Manifolds = "0.10"
 ManifoldsBase = "0.15, 1"
 NLsolve = "3, 4"
@@ -56,9 +64,6 @@ TensorCast = "0.2, 0.3, 0.4"
 TransformUtils = "0.2.17"
 julia = "1.10"
 
-[extensions]
-ApproxManiProdGadflyExt = "Gadfly"
-
 [extras]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -70,6 +75,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["BSON", "DataFrames", "JSON3", "LieGroups", "Rotations", "TensorCast", "Test"]
-
-[weakdeps]
-Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproxManifoldProducts"
 uuid = "9bbbb610-88a1-53cd-9763-118ce10c1f89"
 keywords = ["MM-iSAMv2", "SLAM", "inference", "sum-product", "belief-propagation", "nonparametric", "manifolds", "functional"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -49,7 +49,7 @@ CoordinateTransformations = "0.5, 0.6"
 Distributions = "0.25"
 DocStringExtensions = "0.7, 0.8, 0.9"
 KernelDensityEstimate = "0.5.10"
-LieGroups = "0.1.2"
+LieGroups = "0.1.3"
 Manifolds = "0.10"
 ManifoldsBase = "0.15, 1"
 NLsolve = "3, 4"

--- a/examples/AMP41_dev.jl
+++ b/examples/AMP41_dev.jl
@@ -29,7 +29,7 @@ end
 
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 N = 128
 
 

--- a/examples/dev_BallTreeDensity.jl
+++ b/examples/dev_BallTreeDensity.jl
@@ -3,7 +3,7 @@
 
 using StaticArrays, Manifolds, NearestNeighbors, Distances
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 N = 100
 # convert point to coordinates
 function coords(p)
@@ -166,7 +166,7 @@ distance(mr.manifold, SVector(1,2),SVector(2,3))
 ##
 
 
-M_se2 = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M_se2 = SpecialEuclideanGroup(2; variant = :right)
 
 
 sI = SMatrix{3,3,Float64}(diagm(ones(3)))

--- a/ext/CircularPlotting.jl
+++ b/ext/CircularPlotting.jl
@@ -24,7 +24,7 @@ function plotCircBeliefs( arr::V;
     beliefs[j] = logpdf ? (x)->log(ar(x)+1.0) : (x)->ar(x) #
   end
 
-  M = SpecialOrthogonal(2)
+  M = SpecialOrthogonalGroup(2)
   e0 = Identity(M)
 
   PL = []

--- a/src/API.jl
+++ b/src/API.jl
@@ -39,7 +39,7 @@ function manifoldProduct(
   ndims::Integer=maximum([0;Ndim.(ff)]),
   N::Integer = maximum([0;Npts.(ff)]),
   u0 = getPoints(ff[1], false)[1],
-  oldPoints::AbstractVector{P}= [identity_element(mani, u0) for i in 1:N],
+  oldPoints::AbstractVector{P}= [identity_element(mani, typeof(u0)) for i in 1:N],
   addEntropy::Bool=true,
   recordLabels::Bool=false,
   selectedLabels::Vector{Vector{Int}}=Vector{Vector{Int}}(),
@@ -56,7 +56,7 @@ function manifoldProduct(
   end
 
   # TODO DEPRECATE ::NTuple{Symbol} approach
-  manif = convert(Tuple, mani)  #[partialDimsWorkaround]
+  manif = _manifoldtuple(mani)  #[partialDimsWorkaround]
   addopT, diffopT, getManiMu, _ = buildHybridManifoldCallbacks(manif)
   
   Ndens = length(ff)

--- a/src/ApproxManifoldProducts.jl
+++ b/src/ApproxManifoldProducts.jl
@@ -22,9 +22,9 @@ using CoordinateTransformations
 using RecursiveArrayTools: ArrayPartition
 export ArrayPartition
 
-import ManifoldsBase
-import ManifoldsBase: AbstractManifold, distance
-using Manifolds
+using ManifoldsBase
+using ManifoldsBase: AbstractManifold, distance, TypeParameter, submanifold_component
+import Manifolds
 using LieGroups
 using LieGroups: TranslationGroup
 

--- a/src/ApproxManifoldProducts.jl
+++ b/src/ApproxManifoldProducts.jl
@@ -25,6 +25,8 @@ export ArrayPartition
 import ManifoldsBase
 import ManifoldsBase: AbstractManifold, distance
 using Manifolds
+using LieGroups
+using LieGroups: TranslationGroup
 
 using NLsolve
 import Optim

--- a/src/CommonUtils.jl
+++ b/src/CommonUtils.jl
@@ -87,7 +87,12 @@ end
 function Statistics.var(mkd::ManifoldKernelDensity, aspartial::Bool=true; kwargs...)
   var(_getManifoldFullOrPart(mkd,aspartial), getPoints(mkd, aspartial); kwargs...)
 end
-function Statistics.cov(mkd::ManifoldKernelDensity, aspartial::Bool=true; basis::Manifolds.AbstractBasis = Manifolds.DefaultOrthogonalBasis(), kwargs...)
+function Statistics.cov(
+  mkd::ManifoldKernelDensity,
+  aspartial::Bool=true;
+  basis::ManifoldsBase.AbstractBasis = DefaultOrthogonalBasis(),
+  kwargs...
+)
   return cov(_getManifoldFullOrPart(mkd,aspartial), getPoints(mkd, aspartial); basis, kwargs... )
 end
 # function Statistics.mean(mkd::ManifoldKernelDensity; kwargs...)
@@ -121,7 +126,7 @@ function calcProductGaussians_flat(
   
   # calc the covariance weighted delta means of incoming points and covariances
   ΛΔμc = mapreduce(+, zip(Λ_, μ_)) do (s,u)
-    Δuvee = vee(M, μ0, log(M, μ0, u))
+    Δuvee = vee(LieAlgebra(M), log(M, μ0, u))
     s*Δuvee
   end
 
@@ -167,7 +172,7 @@ function calcProductGaussians(
   # first transport (push forward) covariances to common coordinates
   # see [Ge, van Goor, Mahony, 2024]
   iΔμ = inv(M, Δμ)
-  μi_ = map(u->Manifolds.compose(M,iΔμ,u), μ_)
+  μi_ = map(u->LieGroups.compose(M,iΔμ,u), μ_)
   μi_̂  = map(u->log(M,μ0,u), μi_)
   # μi = map(u->vee(M,μ0,u), μi_̂ )
   Ji = ApproxManifoldProducts.parallel_transport_curvature_2nd_lie.(Ref(M), μi_̂ )
@@ -179,7 +184,7 @@ function calcProductGaussians(
   Δμplusc, Σdiam = ApproxManifoldProducts.calcProductGaussians_flat(M, μi_, Σi_hat; μ0, weight)
   Δμplus_̂  = hat(M, μ0, Δμplusc)
   Δμplus = exp(M, μ0, Δμplus_̂ )
-  μ_plus = Manifolds.compose(M,Δμ,Δμplus)
+  μ_plus = LieGroups.compose(M,Δμ,Δμplus)
   Jμ = ApproxManifoldProducts.parallel_transport_curvature_2nd_lie(M, Δμplus_̂ )
   Σ_plus = Jμ*Σdiam*(Jμ')
   

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -21,7 +21,7 @@
 
 
 @deprecate R(th::Real) _Rot.RotMatrix2(th).mat # = [[cos(th);-sin(th)]';[sin(th);cos(th)]'];
-@deprecate R(;x::Real=0.0,y::Real=0.0,z::Real=0.0) (M=SpecialOrthogonal(3);exp(M,identity_element(M),hat(M,Identity(M),[x,y,z]))) # convert(SO3, so3([x,y,z]))
+@deprecate R(;x::Real=0.0,y::Real=0.0,z::Real=0.0) (M=SpecialOrthogonalGroup(3);exp(M,identity_element(M),hat(M,Identity(M),[x,y,z]))) # convert(SO3, so3([x,y,z]))
 
 export calcCovarianceBasic
 # Returns the covariance (square), not deviation

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -14,20 +14,31 @@ Helper function to convert coordinates to a desired on-manifold point.
 
 DevNotes
 - FIXME need much better consolidation or even removal of this function entirely.
-  - This function makes too strong an assumption of groups
+  - This function is only implemented on Lie groups
 
 Notes
 - `u0` is used to identify the data type for a point
 - Pass in a different `exp` if needed.
 """
-makePointFromCoords(
-  M::MB.AbstractManifold,  # Manifolds.AbstractGroupManifold
+function makePointFromCoords(
+  G::AbstractLieGroup,
   coords::AbstractVector{<:Real},
-  u0=zeros(manifold_dimension(M)),
-  ϵ=identity_element(M, typeof(u0)),
-  retraction_method::AbstractRetractionMethod=ExponentialRetraction()  
-) = retract(M, ϵ, hat(M, ϵ, coords), retraction_method)
-#
+  u0=zeros(manifold_dimension(G)),
+)
+  X = hat(LieAlgebra(G), coords, typeof(u0))
+  return exp(G, X)
+end
+
+function makePointFromCoords(
+  G::SpecialEuclideanGroup,
+  coords::AbstractVector{<:Real},
+  u0=zeros(manifold_dimension(G)),
+)
+  X = hat(LieAlgebra(G), coords, typeof(u0))
+  ε = identity_element(G, typeof(u0))
+  #TODO - review - Force TR-coordinates on SE(n)
+  return exp(base_manifold(G), ε, X)
+end
 
 # should perhaps just be dispatched for <:AbstractGroupManifold
 # only works for AbstractGroupManifold (have an identity)
@@ -35,9 +46,19 @@ makePointFromCoords(
 function makeCoordsFromPoint(
   G::AbstractLieGroup,
   pt,
-  ϵ = identity_element(G, typeof(pt)) 
 )
-  vee(LieAlgebra(G), log(G, ϵ, pt))
+  vee(LieAlgebra(G), log(G, pt))
+end
+
+function makeCoordsFromPoint(
+  G::SpecialEuclideanGroup,
+  pt,
+)
+  #TODO - review - Force TR-coordinates on SE(n)
+  p = ArrayPartition(ManifoldsBase.submanifold_components(G, pt))
+  ϵ = identity_element(G, typeof(p))
+  X = log(base_manifold(G), ϵ, p)
+  return vee(LieAlgebra(G), X)
 end
 
 # Sphere(2) has 3 coords, even though the manifolds only has 2 dimensions (degrees of freedom)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -20,20 +20,24 @@ Notes
 - `u0` is used to identify the data type for a point
 - Pass in a different `exp` if needed.
 """
-makePointFromCoords(M::MB.AbstractManifold,  # Manifolds.AbstractGroupManifold
-                    coords::AbstractVector{<:Real},
-                    u0=zeros(manifold_dimension(M)),
-                    ϵ=identity_element(M,u0),
-                    retraction_method::AbstractRetractionMethod=ExponentialRetraction()  ) = retract(M, ϵ, hat(M, ϵ, coords), retraction_method)
+makePointFromCoords(
+  M::MB.AbstractManifold,  # Manifolds.AbstractGroupManifold
+  coords::AbstractVector{<:Real},
+  u0=zeros(manifold_dimension(M)),
+  ϵ=identity_element(M, typeof(u0)),
+  retraction_method::AbstractRetractionMethod=ExponentialRetraction()  
+) = retract(M, ϵ, hat(M, ϵ, coords), retraction_method)
 #
 
 # should perhaps just be dispatched for <:AbstractGroupManifold
 # only works for AbstractGroupManifold (have an identity)
-function makeCoordsFromPoint( M::MB.AbstractManifold,
-                              pt::P,
-                              ϵ = identity_element(M, pt) ) where P
-  #
-  vee(M, ϵ, log(M, ϵ, pt))
+
+function makeCoordsFromPoint(
+  G::AbstractLieGroup,
+  pt,
+  ϵ = identity_element(G, typeof(pt)) 
+)
+  vee(LieAlgebra(G), log(G, ϵ, pt))
 end
 
 # Sphere(2) has 3 coords, even though the manifolds only has 2 dimensions (degrees of freedom)
@@ -58,7 +62,7 @@ end
 
 function _pointsToMatrixCoords(M::MB.AbstractManifold, pts::AbstractVector{P}) where P
   mat = zeros(manifold_dimension(M), length(pts))
-  ϵ = identity_element(M, pts[1])
+  ϵ = identity_element(M, typeof(pts[1]))
   for (j,pt) in enumerate(pts)
     mat[:,j] = vee(M, ϵ, log(M, ϵ, pt))
   end
@@ -134,16 +138,22 @@ end
 
 #TODO workaround for supporting bitstypes, need rewrite, can consider `PowerManifoldNestedReplacing` or similar, maybe copyto!
 function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{U}, destIdx, srcIdx=destIdx) where {T<:AbstractArray,U<:AbstractArray}
-  if isbitstype(T)
+  if isbitstype(T) || T <: AbstractArray{<:Number, 0}
     dest[destIdx] = src[srcIdx]
   else
     setPointsMani!(dest[destIdx],src[srcIdx])
   end
 end
 
-function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{U}, destIdx) where {T <: AbstractArray, U <: Real}
+function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{T}, destIdx, srcIdx=destIdx) where {T<:Array{<:Number, 0}}
+  dest[destIdx] = src[srcIdx]
+end
+
+function setPointsMani!(dest::AbstractArray{T}, src::AbstractArray{U}, destIdx) where {T <: AbstractArray, U <: Number}
   if isbitstype(T)
     dest[destIdx] = src
+  elseif T <: AbstractArray{<:Number, 0}
+    dest[destIdx] = fill(src[1])
   else
     setPointsMani!(dest[destIdx], src)
   end

--- a/src/Legacy.jl
+++ b/src/Legacy.jl
@@ -48,8 +48,8 @@ function buildHybridManifoldCallbacks(manif::Tuple)
 end
 
 # FIXME TO BE REMOVED
-_MtoSymbol(::Euclidean{Tuple{1}}) = :Euclid
-_MtoSymbol(::Circle) = :Circular
+# _MtoSymbol(::Euclidean{Tuple{1}}) = :Euclid
+# _MtoSymbol(::Circle) = :Circular
 
 function _manifoldtuple(M::AbstractManifold)
   # TODO WIP to remove convert(Tuple, M) type piracy.
@@ -57,28 +57,22 @@ function _manifoldtuple(M::AbstractManifold)
   @warn "Please use `_manifoldtuple(M)` instead. This will be removed (hopefully soon). Got" typeof(M)
   convert(Tuple, M)
 end
-_manifoldtuple(M::ProductManifold) = _MtoSymbol.(M.manifolds)
-_manifoldtuple(M::Manifolds.TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
+# _manifoldtuple(M::ProductManifold) = _MtoSymbol.(M.manifolds)
+# _manifoldtuple(M::Manifolds.TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
 _manifoldtuple(M::LieGroups.TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
 _manifoldtuple(::typeof(LieGroups.CircleGroup(ℝ))) = (:Circular,)
-_manifoldtuple(::LieGroup{ℂ, AbelianMultiplicationGroupOperation, Circle{ℂ}}) = (:Euclid,)
+_manifoldtuple(::LieGroup{ℂ, AbelianMultiplicationGroupOperation, Manifolds.Circle{ℂ}}) = (:Euclid,)
 _manifoldtuple(M::ValidationLieGroup) = _manifoldtuple(M.lie_group)
 
 _manifoldtuple(::Manifolds.Euclidean{Tuple{N}, ℝ} ) where N = tuple([:Euclid for i in 1:N]...)
-_manifoldtuple(::Manifolds.Circle{ℝ})  = error("#FIXME")#(:Circular,)
-_manifoldtuple(::Manifolds.RealCircleGroup)  = (:Circular,)
+# _manifoldtuple(::Manifolds.Circle{ℝ})  = error("#FIXME")#(:Circular,)
+# _manifoldtuple(::Manifolds.RealCircleGroup)  = (:Circular,)
 
 _manifoldtuple(::typeof(Euclid)) = (:Euclid,)
 _manifoldtuple(::typeof(Euclid2)) = (:Euclid,:Euclid)
 _manifoldtuple(::typeof(Euclid3)) = (:Euclid,:Euclid,:Euclid)
 _manifoldtuple(::typeof(Euclid4)) = (:Euclid,:Euclid,:Euclid,:Euclid)
-_manifoldtuple(::typeof(SE2_Manifold)) = (:Euclid,:Euclid,:Circular)
-_manifoldtuple(::typeof(SE3_Manifold)) = (:Euclid,:Euclid,:Euclid,:Circular,:Circular,:Circular)
 
-# _manifoldtuple(::Type{<: typeof(Manifolds.SpecialOrthogonal(2))}) = (:Circular,)
-# _manifoldtuple(::Type{<: typeof(Manifolds.SpecialOrthogonal(3))}) = (:Circular,:Circular,:Circular)
-_manifoldtuple(::typeof(Manifolds.SpecialOrthogonal(2))) = (:Circular,)
-_manifoldtuple(::typeof(Manifolds.SpecialOrthogonal(3))) = (:Circular,:Circular,:Circular)
 _manifoldtuple(::typeof(SpecialOrthogonalGroup(2))) = (:Circular,)
 _manifoldtuple(::typeof(SpecialOrthogonalGroup(3))) = (:Circular,:Circular,:Circular)
 _manifoldtuple(::typeof(SpecialEuclideanGroup(2; variant=:right))) = (:Euclid,:Euclid,:Circular)

--- a/src/Legacy.jl
+++ b/src/Legacy.jl
@@ -50,34 +50,40 @@ end
 # FIXME TO BE REMOVED
 _MtoSymbol(::Euclidean{Tuple{1}}) = :Euclid
 _MtoSymbol(::Circle) = :Circular
-Base.convert(::Type{<:Tuple}, M::ProductManifold) = _MtoSymbol.(M.manifolds)
-Base.convert(::Type{<:Tuple}, M::TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
 
-Base.convert(::Type{<:Tuple}, ::Type{<:Manifolds.Euclidean{Tuple{N}, ℝ}} ) where N = tuple([:Euclid for i in 1:N]...)
-Base.convert(::Type{<:Tuple}, ::Type{<:Manifolds.Circle{ℝ}})  = error("#FIXME")#(:Circular,)
-Base.convert(::Type{<:Tuple}, ::Type{<:Manifolds.RealCircleGroup})  = (:Circular,)
-Base.convert(::Type{<:Tuple}, ::Manifolds.Euclidean{Tuple{N}, ℝ} ) where N = tuple([:Euclid for i in 1:N]...)
-Base.convert(::Type{<:Tuple}, ::Manifolds.Circle{ℝ})  = error("#FIXME")#(:Circular,)
-Base.convert(::Type{<:Tuple}, ::Manifolds.RealCircleGroup)  = (:Circular,)
+function _manifoldtuple(M::AbstractManifold)
+  # TODO WIP to remove convert(Tuple, M) type piracy.
+  # Also easier dev experience without so many convert (800+) and implicit conversion.
+  @warn "Please use `_manifoldtuple(M)` instead. This will be removed (hopefully soon). Got" typeof(M)
+  convert(Tuple, M)
+end
+_manifoldtuple(M::ProductManifold) = _MtoSymbol.(M.manifolds)
+_manifoldtuple(M::Manifolds.TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
+_manifoldtuple(M::LieGroups.TranslationGroup) = tuple([:Euclid for i in 1:manifold_dimension(M)]...)
+_manifoldtuple(::typeof(LieGroups.CircleGroup(ℝ))) = (:Circular,)
+_manifoldtuple(::LieGroup{ℂ, AbelianMultiplicationGroupOperation, Circle{ℂ}}) = (:Euclid,)
+_manifoldtuple(M::ValidationLieGroup) = _manifoldtuple(M.lie_group)
 
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Euclid)}) = (:Euclid,)
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Euclid2)}) = (:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Euclid3)}) = (:Euclid,:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Euclid4)}) = (:Euclid,:Euclid,:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(SE2_Manifold)}) = (:Euclid,:Euclid,:Circular)
-Base.convert(::Type{<:Tuple}, ::Type{<: typeof(SE3_Manifold)}) = (:Euclid,:Euclid,:Euclid,:Circular,:Circular,:Circular)
+_manifoldtuple(::Manifolds.Euclidean{Tuple{N}, ℝ} ) where N = tuple([:Euclid for i in 1:N]...)
+_manifoldtuple(::Manifolds.Circle{ℝ})  = error("#FIXME")#(:Circular,)
+_manifoldtuple(::Manifolds.RealCircleGroup)  = (:Circular,)
 
-# Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Manifolds.SpecialOrthogonal(2))}) = (:Circular,)
-# Base.convert(::Type{<:Tuple}, ::Type{<: typeof(Manifolds.SpecialOrthogonal(3))}) = (:Circular,:Circular,:Circular)
-Base.convert(::Type{<:Tuple}, ::typeof(Manifolds.SpecialOrthogonal(2))) = (:Circular,)
-Base.convert(::Type{<:Tuple}, ::typeof(Manifolds.SpecialOrthogonal(3))) = (:Circular,:Circular,:Circular)
+_manifoldtuple(::typeof(Euclid)) = (:Euclid,)
+_manifoldtuple(::typeof(Euclid2)) = (:Euclid,:Euclid)
+_manifoldtuple(::typeof(Euclid3)) = (:Euclid,:Euclid,:Euclid)
+_manifoldtuple(::typeof(Euclid4)) = (:Euclid,:Euclid,:Euclid,:Euclid)
+_manifoldtuple(::typeof(SE2_Manifold)) = (:Euclid,:Euclid,:Circular)
+_manifoldtuple(::typeof(SE3_Manifold)) = (:Euclid,:Euclid,:Euclid,:Circular,:Circular,:Circular)
 
-Base.convert(::Type{<:Tuple}, ::typeof(Euclid)) = (:Euclid,)
-Base.convert(::Type{<:Tuple}, ::typeof(Euclid2)) = (:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::typeof(Euclid3)) = (:Euclid,:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::typeof(Euclid4)) = (:Euclid,:Euclid,:Euclid,:Euclid)
-Base.convert(::Type{<:Tuple}, ::typeof(SE2_Manifold)) = (:Euclid,:Euclid,:Circular)
-Base.convert(::Type{<:Tuple}, ::typeof(SE3_Manifold)) = (:Euclid,:Euclid,:Euclid,:Circular,:Circular,:Circular)
+# _manifoldtuple(::Type{<: typeof(Manifolds.SpecialOrthogonal(2))}) = (:Circular,)
+# _manifoldtuple(::Type{<: typeof(Manifolds.SpecialOrthogonal(3))}) = (:Circular,:Circular,:Circular)
+_manifoldtuple(::typeof(Manifolds.SpecialOrthogonal(2))) = (:Circular,)
+_manifoldtuple(::typeof(Manifolds.SpecialOrthogonal(3))) = (:Circular,:Circular,:Circular)
+_manifoldtuple(::typeof(SpecialOrthogonalGroup(2))) = (:Circular,)
+_manifoldtuple(::typeof(SpecialOrthogonalGroup(3))) = (:Circular,:Circular,:Circular)
+_manifoldtuple(::typeof(SpecialEuclideanGroup(2; variant=:right))) = (:Euclid,:Euclid,:Circular)
+_manifoldtuple(::typeof(SpecialEuclideanGroup(3; variant=:right))) = (:Euclid,:Euclid,:Euclid,:Circular,:Circular,:Circular)
+_manifoldtuple(::typeof(TranslationGroup(2) × SpecialOrthogonalGroup(2))) = (:Euclid,:Euclid,:Circular)
 
 """
     $(SIGNATURES)

--- a/src/entities/ManifoldDefinitions.jl
+++ b/src/entities/ManifoldDefinitions.jl
@@ -27,7 +27,7 @@ const _AMP_CIRCLE = Manifolds.Circle()
 
 
 # this is just wrong and needs to be fixed
-const Circle1 = Circle()
+const Circle1 = Manifolds.Circle()
 
 const Euclid =  TranslationGroup(1)
 const EuclideanManifold = Euclid
@@ -37,8 +37,8 @@ const Euclid3 = TranslationGroup(3)
 const Euclid4 = TranslationGroup(4)
 
 # TODO if not easy simplification exists, then just deprecate this
-const SE2_Manifold = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
-const SE3_Manifold = SpecialEuclidean(3; vectors=HybridTangentRepresentation())
+const SE2_Manifold = SpecialEuclideanGroup(2; variant = :right)
+const SE3_Manifold = SpecialEuclideanGroup(3; variant = :right)
 
 
 

--- a/src/entities/ManifoldKernelDensity.jl
+++ b/src/entities/ManifoldKernelDensity.jl
@@ -13,7 +13,7 @@ Notes
 DevNotes
 - WIP AMP issue 41, use generic retractions during manifold products.
 """
-struct ManifoldKernelDensity{M <: MB.AbstractManifold, B <: TreeDensity, L, P <: AbstractArray}
+struct ManifoldKernelDensity{M <: MB.AbstractManifold, B <: TreeDensity, L, P}
   manifold::M
   """ legacy expects matrix of coordinates (as columns) """
   belief::B

--- a/src/services/KernelEval.jl
+++ b/src/services/KernelEval.jl
@@ -98,7 +98,7 @@ function distanceMalahanobisCoordinates(
   p = mean(K)
   i_p = inv(M,p)
   pq = Manifolds.compose(M, i_p, q)
-  ϵ = identity_element(M,q)
+  ϵ = identity_element(M, typeof(q))
   X = log(M, ϵ, pq)
   Xc = get_coordinates(M, ϵ, X, basis)
   return K.sqrt_iΣ*Xc

--- a/src/services/KernelEval.jl
+++ b/src/services/KernelEval.jl
@@ -5,7 +5,7 @@ function projectSymPosDef(c::AbstractMatrix)
   # pretty fast to make or remake isbitstype form matrix
   _c = SMatrix{s...}(c)
   #TODO likely not intended project here: see AMP#283
-  issymmetric(_c) ? _c : project(SymmetricPositiveDefinite(s[1]),_c,_c)
+  issymmetric(_c) ? _c : project(Manifolds.SymmetricPositiveDefinite(s[1]),_c,_c)
 end
 
 function MvNormalKernel(
@@ -97,10 +97,24 @@ function distanceMalahanobisCoordinates(
 )
   p = mean(K)
   i_p = inv(M,p)
-  pq = Manifolds.compose(M, i_p, q)
+  pq = LieGroups.compose(M, i_p, q)
   ϵ = identity_element(M, typeof(q))
   X = log(M, ϵ, pq)
   Xc = get_coordinates(M, ϵ, X, basis)
+  return K.sqrt_iΣ*Xc
+end
+
+function distanceMalahanobisCoordinates(
+  M::AbstractLieGroup, 
+  K::AbstractKernel, 
+  q,
+  # basis=DefaultOrthogonalBasis()
+)
+  p = mean(K)
+  i_p = inv(M,p)
+  pq = LieGroups.compose(M, i_p, q)
+  X = log(M, pq)
+  Xc = vee(LieAlgebra(M), X)
   return K.sqrt_iΣ*Xc
 end
 
@@ -111,6 +125,17 @@ function distanceMalahanobisSq(
   basis=DefaultOrthogonalBasis()
 )
   δc = distanceMalahanobisCoordinates(M,K,q,basis)
+  # return inner(M, p, X, X) # did not work as inner gave almost 2x the answer?
+  return δc'*δc
+end
+
+function distanceMalahanobisSq(
+  M::AbstractLieGroup,
+  K::AbstractKernel,
+  q,
+  # basis=DefaultOrthogonalBasis()
+)
+  δc = distanceMalahanobisCoordinates(M,K,q)
   # return inner(M, p, X, X) # did not work as inner gave almost 2x the answer?
   return δc'*δc
 end

--- a/src/services/ManellicTree.jl
+++ b/src/services/ManellicTree.jl
@@ -292,7 +292,7 @@ DeVNotes:
 - FIXME use manifold mean and cov calculation instead
 """
 function splitPointsEigen(
-  M::AbstractManifold,
+  M::AbstractLieGroup,
   r_PP::AbstractVector{P},
   weights::AbstractVector{<:Real} = ones(length(r_PP)); # FIXME, make static vector unless large
   kernel = MvNormalKernel,
@@ -306,15 +306,15 @@ function splitPointsEigen(
   p = mean(M, r_PP)
   
   r_XXp = log.(Ref(M), Ref(p), r_PP) # FIXME replace with on-manifold distance
-  r_CCp = vee.(Ref(M), Ref(p), r_XXp)
-  
+  r_CCp = vee.(Ref(LieAlgebra(M)), r_XXp)
+
   D = manifold_dimension(M)
   ndia = ( (D-1) ÷ 2 + 1 ) * D
   # FIXME, consider user provided bandwidth in estimating multisample covariance
   cv = if ndia < len
-    SMatrix{D,D,Float64}(Manifolds.cov(M, r_PP))
+    SMatrix{D,D,Float64}(Manifolds.cov(M, r_PP; basis = DefaultLieAlgebraOrthogonalBasis()))
   elseif 1 < len <= ndia
-    SMatrix{D,D,Float64}(diagm(diag(Manifolds.cov(M, r_PP))))
+    SMatrix{D,D,Float64}(diagm(diag(Manifolds.cov(M, r_PP; basis = DefaultLieAlgebraOrthogonalBasis()))))
   else
     # TODO case with user defined bandwidth for faster tree construction
     bw = isnothing(kernel_bw) ? SMatrix{D,D,Float64}(diagm(eps(Float64)*ones(D))) : kernel_bw

--- a/src/services/ManifoldKernelDensity.jl
+++ b/src/services/ManifoldKernelDensity.jl
@@ -55,7 +55,7 @@ function ManifoldKernelDensity(
   M::MB.AbstractManifold,
   vecP::AbstractVector{P},
   u0 = vecP[1],
-  ϵ = identity_element(M, u0); # vecP[1]
+  ϵ = identity_element(M, typeof(u0)); # vecP[1]
   partial::L=nothing,
   infoPerCoord::AbstractVector{<:Real}=ones(getNumberCoords(M, u0)),
   dims::Int=manifold_dimension(M),
@@ -67,11 +67,11 @@ function ManifoldKernelDensity(
   arr = Matrix{Float64}(undef, dims, length(vecP))
   
   for j in 1:length(vecP)
-    arr[:,j] = vee(M, ϵ, log(M, ϵ, vecP[j]))
+    arr[:,j] = vee(LieAlgebra(M), log(M, ϵ, vecP[j]))
   end
 
     # FIXME ON FIRE REMOVE LEGACY
-    manis = convert(Tuple, M)
+    manis = _manifoldtuple(M)
     # find or have the bandwidth
     _bw = isnothing(bw) ? getKDEManifoldBandwidths(arr, manis ) : bw
   # NOTE workaround for partials and user did not specify a bw
@@ -191,7 +191,7 @@ function _buildManifoldPartial( fullM::MB.AbstractManifold,
                                 partial_coord_dims )
   #
   # temporary workaround during Manifolds.jl integration
-  manif = convert(Tuple, fullM)[partial_coord_dims]
+  manif = _manifoldtuple(fullM)[partial_coord_dims]
   # 
   newMani = MB.AbstractManifold[]
   for me in manif

--- a/src/services/ManifoldKernelDensity.jl
+++ b/src/services/ManifoldKernelDensity.jl
@@ -67,7 +67,7 @@ function ManifoldKernelDensity(
   arr = Matrix{Float64}(undef, dims, length(vecP))
   
   for j in 1:length(vecP)
-    arr[:,j] = vee(LieAlgebra(M), log(M, ϵ, vecP[j]))
+    arr[:,j] = makeCoordsFromPoint(M, vecP[j])
   end
 
     # FIXME ON FIRE REMOVE LEGACY

--- a/src/services/ManifoldPartials.jl
+++ b/src/services/ManifoldPartials.jl
@@ -101,7 +101,7 @@ function getManifoldPartial(M::TranslationGroup{Tuple{N}},
   return (TranslationGroup(len),repr_p)
 end
 
-function getManifoldPartial(M::typeof(SpecialOrthogonal(2)), 
+function getManifoldPartial(M::typeof(SpecialOrthogonalGroup(2)), 
                             partial::AbstractVector{Int}, 
                             repr::_PartiableRepresentation=nothing,
                             offset::Base.RefValue{Int}=Ref(0);
@@ -174,6 +174,51 @@ function getManifoldPartial(M::ProductManifold,
   ManiArr = []
   ReprArr = []
   for (i,m) in enumerate(M.manifolds)
+    mask = _checkManifoldPartialDims(m,partial,offset, false)
+    if any(mask)
+      Mp = if repr === nothing
+        # decide if representation should also be updated or left as nothing
+        Mp, = getManifoldPartial(m, partial, nothing, offset, doError=false)
+        Mp
+      else
+        # hard assumption that repr::ArrayPartition to go along with M::ProductManifold
+        # NOTE submanifold_component is the correct way to avoid this assumption
+        Mp, Rp = getManifoldPartial(m, partial, submanifold_component(repr,i), offset, doError=false)
+        push!(ReprArr, Rp)
+        Mp
+      end
+      push!(ManiArr, Mp)
+    else
+      offset[] += manifold_dimension(m)
+    end
+  end
+
+  # trivial case, drop the ProductManifold for single element
+  if length(ManiArr) == 1
+    repr_p = repr === nothing ? nothing : ReprArr[1]
+    return (ManiArr[1],repr_p)
+  elseif 1 < length(ManiArr)
+    repr_p = repr === nothing ? nothing : ArrayPartition(ReprArr...)
+    return (ProductManifold(ManiArr...), repr_p)
+  end
+  error("partial manifold calculations should not reach here")
+end
+
+function getManifoldPartial(
+  PrG::LieGroup{ℝ, <:ProductGroupOperation, <:ProductManifold},
+  partial::AbstractVector{Int},
+  repr::_PartiableRepresentationProduct=nothing,
+  offset::Base.RefValue{Int}=Ref(0);
+  doError::Bool=true
+  )
+  _checkManifoldPartialDims(PrG,partial,offset,doError)
+
+  # loop through the ProductManifold components 
+  ManiArr = []
+  ReprArr = []
+  
+  subgroups = map(LieGroup, PrG.manifold.manifolds, PrG.op.operations)
+  for (i,m) in enumerate(subgroups)
     mask = _checkManifoldPartialDims(m,partial,offset, false)
     if any(mask)
       Mp = if repr === nothing

--- a/src/services/ManifoldPartials.jl
+++ b/src/services/ManifoldPartials.jl
@@ -39,13 +39,14 @@ function _getReprPartial( M::MB.AbstractManifold,
   return ret
 end
 
-function _getReprPartial( M::Union{<:typeof(SpecialOrthogonal(2)), <:Rotations{ManifoldsBase.TypeParameter{Tuple{2}}}}, 
-                          repr::AbstractMatrix{T}, 
-                          partial::AbstractVector{Int}, # total partial from user over all Factors
-                          offset::Base.RefValue{Int}=Ref(0),
-                          mask::BitVector=_checkManifoldPartialDims(M,partial,offset, false) ) where {T <: Number}
-  #
-  @assert sum(mask) == 1 "Can only return the same point represenation matrix for SpecialOrthogonal(2) / Rotations(2)"
+function _getReprPartial(
+  M::Union{<:typeof(SpecialOrthogonalGroup(2)), <: Manifolds.Rotations{TypeParameter{Tuple{2}}}}, 
+  repr::AbstractMatrix{T}, 
+  partial::AbstractVector{Int}, # total partial from user over all Factors
+  offset::Base.RefValue{Int}=Ref(0),
+  mask::BitVector=_checkManifoldPartialDims(M,partial,offset, false) 
+) where {T <: Number}
+  @assert sum(mask) == 1 "Can only return the same point represenation matrix for SpecialOrthogonalGroup(2) / Rotations(2)"
   return repr
 end
 
@@ -53,12 +54,13 @@ end
 ## EXTRACT PARTIAL MANIFOLD
 
 
-function getManifoldPartial(M::Union{<:Euclidean{Tuple{N}},<:TranslationGroup}, 
-                            partial::AbstractVector{Int}, 
-                            repr::_PartiableRepresentationFlat{T}=nothing,
-                            offset::Base.RefValue{Int}=Ref(0);
-                            doError::Bool=true) where {N, T <: Number}
-  #
+function getManifoldPartial(
+  M::Union{<:Manifolds.Euclidean{Tuple{N}},<:TranslationGroup}, 
+  partial::AbstractVector{Int}, 
+  repr::_PartiableRepresentationFlat{T}=nothing,
+  offset::Base.RefValue{Int}=Ref(0);
+  doError::Bool=true
+) where {N, T <: Number}
   mask = _checkManifoldPartialDims(M,partial,offset, doError)
   offset[] += manifold_dimension(M)
   len = sum(mask)
@@ -66,18 +68,19 @@ function getManifoldPartial(M::Union{<:Euclidean{Tuple{N}},<:TranslationGroup},
   return (TranslationGroup(len),repr_p)
 end
 
-function getManifoldPartial(M::Circle, 
-                            partial::AbstractVector{Int}, 
-                            repr::_PartiableRepresentation=nothing,
-                            offset::Base.RefValue{Int}=Ref(0);
-                            doError::Bool=true )
-  #
+function getManifoldPartial(
+  M::Manifolds.Circle, 
+  partial::AbstractVector{Int}, 
+  repr::_PartiableRepresentation=nothing,
+  offset::Base.RefValue{Int}=Ref(0);
+  doError::Bool=true
+)
   mask = _checkManifoldPartialDims(M,partial,offset,doError)
   offset[] += manifold_dimension(M)
   return (M,repr)
 end
 
-function getManifoldPartial(M::Rotations{ManifoldsBase.TypeParameter{Tuple{2}}}, 
+function getManifoldPartial(M::Manifolds.Rotations{TypeParameter{Tuple{2}}}, 
                             partial::AbstractVector{Int}, 
                             repr::_PartiableRepresentation=nothing,
                             offset::Base.RefValue{Int}=Ref(0);
@@ -126,7 +129,7 @@ using Manifolds
 using ApproxManifoldProducts
 
 # a familiar manifold of translation and rotation in 2D
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 
 
 # make a new partial of only the translation components
@@ -142,11 +145,11 @@ u0 = ArrayPartition([0.0;0],[1 0; 0 1.0])
 
 # make another new partial of only the rotation component
 M_rot, u_rot = getManifoldPartial(M,[3],u0)
-# returns SpecialOrthogonal(2) information
+# returns SpecialOrthogonalGroup(2) information
 
 # make another new partial of only  y and θ
 M_yθ, u_yθ = getManifoldPartial(M,[2;3],u0)
-# returns new manifold information as ProductArray(TranslationGroup(1),SpecialOrthogonal(2))
+# returns new manifold information as ProductArray(TranslationGroup(1),SpecialOrthogonalGroup(2))
 ```
 
 Notes
@@ -228,7 +231,7 @@ function getManifoldPartial(
       else
         # hard assumption that repr::ArrayPartition to go along with M::ProductManifold
         # NOTE submanifold_component is the correct way to avoid this assumption
-        Mp, Rp = getManifoldPartial(m, partial, submanifold_component(repr,i), offset, doError=false)
+        Mp, Rp = getManifoldPartial(m, partial, submanifold_component(PrG, repr, i), offset, doError=false)
         push!(ReprArr, Rp)
         Mp
       end
@@ -244,28 +247,52 @@ function getManifoldPartial(
     return (ManiArr[1],repr_p)
   elseif 1 < length(ManiArr)
     repr_p = repr === nothing ? nothing : ArrayPartition(ReprArr...)
-    return (ProductManifold(ManiArr...), repr_p)
+    return (ProductLieGroup(ManiArr...), repr_p)
   end
   error("partial manifold calculations should not reach here")
 end
 
-function getManifoldPartial(M::GroupManifold, 
-                            partial::AbstractVector{<:Integer}, 
-                            repr::_PartiableRepresentation=nothing,
-                            offset::Base.RefValue{<:Integer}=Ref(0);
-                            doError::Bool=true )
-  #
-  # mask the desired coordinate dimensions
-  mask = _checkManifoldPartialDims(M,partial,offset, doError)
-
-  if sum(mask) == manifold_dimension(M)
-    # asking for all coordinate dimensions as offered by M
-    return (M,repr)
+function getManifoldPartial(
+  M::typeof(SpecialEuclideanGroup(2; variant=:right)), 
+  partial::AbstractVector{Int}, 
+  repr::_PartiableRepresentation=nothing,
+  offset::Base.RefValue{Int}=Ref(0);
+  doError::Bool=true
+)
+  #FIXME This doesn't seem correct:
+  # How is it used?
+  # Is the partial dimension coupled or not?
+  # A SE(2) prior will have different results than a product prior.
+  if partial == [1, 2, 3]
+    return (M, repr)
+  else
+    return getManifoldPartial(
+      ProductLieGroup(TranslationGroup(2), SpecialOrthogonalGroup(2)),
+      partial,
+      repr,
+      offset;
+      doError
+    )
   end
-  # recursion may need to branch for ProductManifold
-  # Note loss of the Group operation information at this time
-  getManifoldPartial(M.manifold, partial, repr, offset, doError=doError)
 end
+
+# function getManifoldPartial(M::AbstractLieGroup, 
+#                             partial::AbstractVector{<:Integer}, 
+#                             repr::_PartiableRepresentation=nothing,
+#                             offset::Base.RefValue{<:Integer}=Ref(0);
+#                             doError::Bool=true )
+#   #
+#   # mask the desired coordinate dimensions
+#   mask = _checkManifoldPartialDims(M,partial,offset, doError)
+
+#   if sum(mask) == manifold_dimension(M)
+#     # asking for all coordinate dimensions as offered by M
+#     return (M,repr)
+#   end
+#   # recursion may need to branch for ProductManifold
+#   # Note loss of the Group operation information at this time
+#   getManifoldPartial(M.manifold, partial, repr, offset, doError=doError)
+# end
 
 
 

--- a/src/services/ManifoldsOverloads.jl
+++ b/src/services/ManifoldsOverloads.jl
@@ -45,6 +45,7 @@ get_basis_affine(
   SA[0 -1 0; 1 0 -0; -0 0 0.0],
 )
 
+# right variant is translate-then-rotate
 get_basis_affine(
   ::typeof(SpecialEuclideanGroup(2; variant=:right))
 ) = tuple(
@@ -53,6 +54,7 @@ get_basis_affine(
   SA[0 -1 0; 1 0 0; 0 0 0.0],
 )
 
+# right variant is translate-then-rotate
 get_basis_affine(
   ::typeof(SpecialEuclideanGroup(3; variant=:right))
 ) = tuple(

--- a/src/services/ManifoldsOverloads.jl
+++ b/src/services/ManifoldsOverloads.jl
@@ -9,10 +9,10 @@ LieGroupManifoldsPirate = Union{
   typeof(TranslationGroup(4)),
   typeof(TranslationGroup(5)),
   typeof(TranslationGroup(6)),
-  typeof(SpecialOrthogonal(2)), 
-  typeof(SpecialOrthogonal(3)), 
-  typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation())), 
-  typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation()))
+  typeof(SpecialOrthogonalGroup(2)), 
+  typeof(SpecialOrthogonalGroup(3)), 
+  typeof(SpecialEuclideanGroup(2; variant = :right)), 
+  typeof(SpecialEuclideanGroup(3; variant = :right))
 }
 
 ## ===================================== BASIS PIRATES =====================================
@@ -25,20 +25,20 @@ LieGroupManifoldsPirate = Union{
 # ```
 
 get_basis_affine(
-  ::TranslationGroup{Manifolds.TypeParameter{Tuple{N}}, ℝ}
+  ::TranslationGroup{ℝ, TypeParameter{Tuple{N}}}
 ) where N = map(
   i->SVector{N,Float64}( ntuple(s->float(s==i),N) ),
   1:N
 )
 
 get_basis_affine(
-  ::typeof(SpecialOrthogonal(2))
+  ::typeof(SpecialOrthogonalGroup(2))
 ) = tuple(
   SA[0 -1; 1 0.0],
 )
 
 get_basis_affine(
-  ::typeof(SpecialOrthogonal(3))
+  ::typeof(SpecialOrthogonalGroup(3))
 ) = tuple(
   SA[0 -0 0; 0 0 -1; -0 1 0.0],
   SA[0 -0 1; 0 0 -0; -1 0 0.0],
@@ -46,7 +46,7 @@ get_basis_affine(
 )
 
 get_basis_affine(
-  ::typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation()))
+  ::typeof(SpecialEuclideanGroup(2; variant=:right))
 ) = tuple(
   SA[0 -0 1; 0 0 0; 0 0 0.0],
   SA[0 -0 0; 0 0 1; 0 0 0.0],
@@ -54,7 +54,7 @@ get_basis_affine(
 )
 
 get_basis_affine(
-  ::typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation()))
+  ::typeof(SpecialEuclideanGroup(3; variant=:right))
 ) = tuple(
   SA[0 -0 0 1; 0 0 -0 0; -0 0 0 0; 0 0 0 0.0],
   SA[0 -0 0 0; 0 0 -0 1; -0 0 0 0; 0 0 0 0.0],
@@ -88,7 +88,7 @@ end
 
 # right Jacobian (Lie Group, originally from ?)
 function Jr(
-  M::Manifolds.GroupManifold, 
+  M::AbstractLieGroup, 
   X; 
   order=5
 )
@@ -141,14 +141,19 @@ parallel_transport_best(
 
 
 _makeaffine(::AbstractManifold, X) = X
-_makeaffine(M::Union{typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation())),typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation()))}, X::ArrayPartition) = screw_matrix(M,X)
+function _makeaffine(
+  ::SpecialEuclideanGroup, 
+  X::ArrayPartition
+)
+  return convert(AbstractMatrix, SpecialEuclideanProductTangentVector(X))
+end
 
 # assumes inputs are Lie algebra tangent vectors represented in matrix form
 ad(
   M::LieGroupManifoldsPirate, 
   X::AbstractMatrix, 
   d::AbstractMatrix
-) = Manifolds.lie_bracket(M, X, d)
+) = LieGroups.lie_bracket(M, X, d)
 
 """
     $SIGNATURES
@@ -162,16 +167,16 @@ Notes
 - Two parameters means this function builds a matrix that can be used to do the action.
 """
 function ad_lie(
-  M::LieGroupManifoldsPirate,
+  M::AbstractLieGroup,
   X::AbstractArray,
 ) 
   #
-  ε = identity_element(M, X)
   Es = get_basis_affine(M)
   Xa = _makeaffine(M,X)
+  𝔤 = LieAlgebra(M)
   hcat(
     map(
-      (e)->vee(M, ε, Manifolds.lie_bracket(M, Xa, e)), # Lie bracket here is also the adjoint action for M
+      (e)->vee(𝔤, LieGroups.lie_bracket(𝔤, Xa, e)), # Lie bracket here is also the adjoint action for M
       Es
     )...
   )
@@ -186,26 +191,26 @@ ad(
 
 
 Ad(
-  M::Union{typeof(SpecialOrthogonal(2)), typeof(SpecialOrthogonal(3))}, 
+  M::Union{typeof(SpecialOrthogonalGroup(2)), typeof(SpecialOrthogonalGroup(3))}, 
   p, 
   X::AbstractMatrix;
   use_upstream::Bool = _UPSTREAM_MANIFOLDS_ADJOINT_ACTION # explict to support R&D
 ) = if use_upstream
-  Manifolds.adjoint_action(M, p, X)
+  LieGroups.adjoint_action(M, p, X)
 else
   p*X*(p')
 end
 
 
 function Ad(
-  M::Union{typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation())), typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation()))}, 
+  M::Union{typeof(SpecialEuclideanGroup(2; variant = :right)), typeof(SpecialEuclideanGroup(3; variant = :right))}, 
   p, 
   X::ArrayPartition;
   use_upstream::Bool = _UPSTREAM_MANIFOLDS_ADJOINT_ACTION # explict to support R&D
 )
   if use_upstream
     # TODO swap and test
-    Manifolds.adjoint_action(M, p, X)
+    LieGroups.adjoint_action(M, p, X)
   else
     t = p.x[1]
     R = p.x[2]
@@ -258,9 +263,8 @@ function parallel_transport_direction_lie(
   X
 )
   hat(
-    M, 
-    Identity(M), 
-    parallel_transport_direction_lie(M, d) * vee(M, Identity(M), X)
+    LieAlgebra(M), 
+    parallel_transport_direction_lie(M, d) * vee(LieAlgebra(M), X)
   )
 end
 
@@ -285,18 +289,18 @@ parallel_transport_best(
 
 
 
-## ----------------------------- SpecialOrthogonal(3) -----------------------------
+## ----------------------------- SpecialOrthogonalGroup(3) -----------------------------
 
 
 # matrix versions
 # [Chirikjian, 2012 Vol2, p.39]
 ad(
-  ::typeof(SpecialOrthogonal(3)), 
+  ::typeof(SpecialOrthogonalGroup(3)), 
   X
 ) = X
 
 Ad(
-  ::typeof(SpecialOrthogonal(3)), 
+  ::typeof(SpecialOrthogonalGroup(3)), 
   R
 ) = R
 
@@ -312,18 +316,17 @@ Ad(
 # d is a Lie algebra element (tangent vector) providing the direction of transport
 # X is the tangent vector to be transported 
 function ad(
-  M::typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation())), 
+  M::typeof(SpecialEuclideanGroup(3; variant = :right)), 
   d::ArrayPartition, 
   X::ArrayPartition
 )
-  #
+  SO3 = SpecialOrthogonalGroup(3)
   v1x = skew(d.x[1])
   Ω1  = d.x[2]
   v2 = X.x[1]
-  ω2 = log_lie(M.manifold[2], X.x[2])
+  ω2 = log(SO3, X.x[2])
 
-  Rε = identity_element(M.manifold[2], Ω1)
-  Ω = Manifolds.hat(M.manifold[2], Rε, Ω1*ω2)
+  Ω = hat(LieGroup(SO3), Ω1*ω2)
 
   ArrayPartition(v1x*ω2 + Ω1*v2, Ω)
 end
@@ -333,7 +336,7 @@ end
 
 
 function ad(
-  ::typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation())), 
+  ::typeof(SpecialEuclideanGroup(2; variant = :right)), 
   d::ArrayPartition, 
 )
   Vx = SA[d.x[1][2]; -d.x[1][1]]
@@ -345,7 +348,7 @@ function ad(
 end
 
 function ad(
-  ::typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation())), 
+  ::typeof(SpecialEuclideanGroup(3; variant = :right)), 
   d::ArrayPartition, 
 )
   Vx = skew(d.x[1])
@@ -358,7 +361,7 @@ end
 
 
 function Ad(
-  ::typeof(SpecialEuclidean(2; vectors=HybridTangentRepresentation())), 
+  ::typeof(SpecialEuclideanGroup(2; variant = :right)), 
   p
 )
   t = p.x[1]
@@ -370,7 +373,7 @@ function Ad(
 end
 
 function Ad(
-  ::typeof(SpecialEuclidean(3; vectors=HybridTangentRepresentation())), 
+  ::typeof(SpecialEuclideanGroup(3; variant = :right)), 
   p
 )
   t = p.x[1]

--- a/test/basic_se3.jl
+++ b/test/basic_se3.jl
@@ -19,7 +19,7 @@ using Test
 
 M = SpecialEuclidean(3; vectors=HybridTangentRepresentation())
 u0 = ArrayPartition(zeros(3),[1 0 0; 0 1 0; 0 0 1.0])
-ϵ = identity_element(M, u0)
+ϵ = identity_element(M, typeof(u0))
 N = 50
 
 pts1 = [exp(M, ϵ, hat(M, ϵ, [0.5*randn(3);0.1*randn(3)])) for i in 1:N]

--- a/test/basic_se3.jl
+++ b/test/basic_se3.jl
@@ -6,7 +6,7 @@ using Test
 
 ##
 
-@testset "Test isapprox function on basic SpecialEuclidean(3; vectors=HybridTangentRepresentation())" begin
+@testset "Test isapprox function on basic SpecialEuclideanGroup(3; variant = :right)" begin
 
 ##
 
@@ -17,7 +17,7 @@ using Test
 # c_[1,:] .+= 50
 # c = kde!(c_)
 
-M = SpecialEuclidean(3; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(3; variant = :right)
 u0 = ArrayPartition(zeros(3),[1 0 0; 0 1 0; 0 0 1.0])
 ϵ = identity_element(M, typeof(u0))
 N = 50

--- a/test/manellic/testManifoldTreeConstr.jl
+++ b/test/manellic/testManifoldTreeConstr.jl
@@ -26,7 +26,7 @@ function testEigenCoords(
   r_C = pi/3,
   ax_CC = [SA[5*randn();randn()] for _ in 1:100],
 )
-  M = MF.TranslationGroup(2)
+  M = TranslationGroup(2)
   _R(α, s=exp(-α*im)) = real(s)*SA[1 0; 0 1] + imag(s)*SA[0 1; -1 0]
   # _R(α) = SA[cos(α) sin(α); -sin(α) cos(α)]
   r_R_ax = _R(r_C)
@@ -38,7 +38,7 @@ function testEigenCoords(
   r_R_ax_, L, pidx = ApproxManifoldProducts.eigenCoords(r_CV)
 
   # spot check
-  @show _ax_ERR = MF.log_lie(MF.SpecialOrthogonal(2), (r_R_ax_')*r_R_ax)[1,2]
+  @show _ax_ERR = log(SpecialOrthogonalGroup(2), (r_R_ax_')*r_R_ax)[1,2]
   @show testval = isapprox(0, _ax_ERR; atol = 8/length(ax_CC))
   @assert testval "Spot check failed on eigen split of manifold points, the estimated point rotation matrix did not match construction. length(ax_CC)=$(length(ax_CC))"
 
@@ -49,14 +49,14 @@ end
 @testset "test ManellicTree construction" begin
 ##
 
-M = MF.TranslationGroup(2)
+M = TranslationGroup(2)
 α = pi/3
 r_CC, R, pidx, r_CV = testEigenCoords(α);
 ax_CCp, mask, knl = splitPointsEigen(M, r_CC)
 @test sum(mask) == (length(r_CC) ÷ 2)
 @test knl isa ApproxManifoldProducts.MvNormalKernel
-Mr = MF.SpecialOrthogonal(2)
-@test isapprox( α, MF.vee(Mr, MF.Identity(Mr), MF.log_lie(Mr, R))[1] ; atol=0.1)
+Mr = SpecialOrthogonalGroup(2)
+@test isapprox( α, vee(LieAlgebra(Mr), log(Mr, R))[1] ; atol=0.1)
 
 ##
 
@@ -117,7 +117,7 @@ end
 @testset "ManellicTree construction 1D" begin
 ##
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 # already sorted list
 pts = [[1.],[2.],[4.],[7.],[11.],[16.],[22.]]
 bw = [1.0]
@@ -147,7 +147,7 @@ function testMDEConstr(
   rseg = 3:4
 )
   # check permutation
-  M = MF.TranslationGroup(1)
+  M = TranslationGroup(1)
   bw = [1.0]
 
   mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel_bw=bw,kernel=AMP.MvNormalKernel)
@@ -203,7 +203,7 @@ end
 
 
 #
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 pts = [randn(1) for _ in 1:8]
 for i in 1:10
   _pts = pts[shuffle(1:length(pts))]
@@ -218,7 +218,7 @@ end
 @testset "ManellicTree 1D basic construction and evaluations" begin
 ## 
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 pts = [randn(1) for _ in 1:128]
 mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel=AMP.MvNormalKernel)
 
@@ -229,7 +229,7 @@ AMP.evaluate(mtree, SA[0.0;])
 json_string = read(joinpath(DATADIR,"manellic_test_data.json"), String)
 dict = JSON3.read(json_string, Dict{Symbol,Vector{Float64}})
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 pts = [[v;] for v in dict[:evaltest_1_pts]]
 bw = reshape(dict[:evaltest_1_bw],1,1)
 mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel_bw=bw,kernel=AMP.MvNormalKernel)
@@ -272,7 +272,7 @@ end
 @testset "Test evaluate MvNormalKernel" begin
 ##
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 ker = AMP.MvNormalKernel([0.0], [0.5;;])
 @test isapprox(
   AMP.evaluate(M, ker, [0.1]),
@@ -289,7 +289,7 @@ function pdf_wrapped_normal(μ, σ, θ; nwrap=1000)
   return 1/(σ*sqrt(2pi)) * s
 end 
 
-M = RealCircleGroup()
+M = LieGroups.CircleGroup(ℝ)
 ker = AMP.MvNormalKernel([0.0], [0.1;;])
 @test isapprox(
   AMP.evaluate(M, ker, [0.1]),
@@ -312,10 +312,10 @@ ker = AMP.MvNormalKernel([0], [2.0;;])
 )
 
 ##
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 ε = identity_element(M)
 Xc = [10, 20, 0.1]
-p = exp(M, ε, hat(M, ε, Xc))
+p = exp(M, hat(LieAlgebra(M), Xc))
 kercov = diagm([0.5, 2.0, 0.1].^2)
 ker = AMP.MvNormalKernel(p, kercov)
 @test isapprox(
@@ -324,15 +324,15 @@ ker = AMP.MvNormalKernel(p, kercov)
 )
 
 Xc = [10, 22, -0.1]
-q = exp(M, ε, hat(M, ε, Xc))
+q = exp(M, hat(LieAlgebra(M), Xc))
 
 @test isapprox(
   pdf(MvNormal(cov(ker)), [0,0,0]),
   AMP.evaluate(M, ker, p)
 )
 
-X = log(M, ε, Manifolds.compose(M, inv(M, p), q))
-Xc_e = vee(M, ε, X)
+X = log(M, LieGroups.compose(M, inv(M, p), q))
+Xc_e = vee(LieAlgebra(M), X)
 pdf_local_coords = pdf(MvNormal(cov(ker)), Xc_e)
 
 @test isapprox(
@@ -341,8 +341,8 @@ pdf_local_coords = pdf(MvNormal(cov(ker)), Xc_e)
 )
 
 delta_c = AMP.distanceMalahanobisCoordinates(M, ker, q)
-X = log(M, ε, Manifolds.compose(M, inv(M, p), q))
-Xc_e = vee(M, ε, X)
+X = log(M, LieGroups.compose(M, inv(M, p), q))
+Xc_e = vee(LieAlgebra(M), X)
 malad_t = Xc_e'*inv(kercov)*Xc_e
 # delta_t = [10, 20, 0.1] - [10, 22, -0.1] 
 @test isapprox(
@@ -367,7 +367,7 @@ rbfd = AMP.ker(M, ker, q, 0.5, AMP.distanceMalahanobisSq)
 
 # NOTE 'global' distribution would have been 
 X = log(M, mean(ker), q) 
-Xc_e = vee(M, ε, X)
+Xc_e = vee(LieAlgebra(M), X)
 pdf_global_coords = pdf(MvNormal(cov(ker)), Xc_e)
 
 
@@ -378,7 +378,7 @@ end
 ## 
 
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 ε = identity_element(M)
 dis = MvNormal([3.0], diagm([1.0].^2)) 
 Cpts = [rand(dis) for _ in 1:128]
@@ -386,7 +386,7 @@ pts = map(c->exp(M, ε, hat(M, ε, c)), Cpts)
 mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel_bw = [0.2;;],  kernel=AMP.MvNormalKernel)
 
 ##
-p = exp(M, ε, hat(M, ε, [3.0]))
+p = exp(M, ε, hat(LieAlgebra(M), [3.0]))
 y_amp = AMP.evaluate(mtree, p)
 
 y_pdf = pdf(dis, [3.0])
@@ -404,15 +404,15 @@ y_pdf = pdf(dis, [3.0])
 # lines(first.(ps), ys_amp)
 ##
 
-M = SpecialOrthogonal(2)
+M = SpecialOrthogonalGroup(2)
 ε = identity_element(M)
 dis = MvNormal([0.0], diagm([0.1].^2)) 
 Cpts = [rand(dis) for _ in 1:128]
-pts = map(c->exp(M, ε, hat(M, ε, c)), Cpts)
+pts = map(c->exp(M, hat(LieAlgebra(M), c)), Cpts)
 mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel_bw = [0.005;;], kernel=AMP.MvNormalKernel)
 
 ##
-p = exp(M, ε, hat(M, ε, [0.1]))
+p = exp(M, ε, hat(LieAlgebra(M), [0.1]))
 y_amp = AMP.evaluate(mtree, p)
 
 y_pdf = pdf(dis, [0.1])
@@ -420,22 +420,22 @@ y_pdf = pdf(dis, [0.1])
 @test isapprox(y_amp, y_pdf; atol=0.5)
 
 ps = [[p] for p = -0.3:0.01:0.3]
-ys_amp = map(p->AMP.evaluate(mtree, exp(M, ε, hat(M, ε, p))), ps)
+ys_amp = map(p->AMP.evaluate(mtree, exp(M, ε, hat(LieAlgebra(M), p))), ps)
 ys_pdf = pdf(dis, ps)
 
 # lines(first.(ps), ys_pdf)
 # lines!(first.(ps), ys_amp)
 
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 ε = identity_element(M)
 dis = MvNormal([10,20,0.1], diagm([0.5,2.0,0.1].^2)) 
 Cpts = [rand(dis) for _ in 1:128]
-pts = map(c->exp(M, ε, hat(M, ε, c)), Cpts)
+pts = map(c->exp(M, ε, hat(LieAlgebra(M), c)), Cpts)
 mtree = ApproxManifoldProducts.buildTree_Manellic!(M, pts; kernel_bw = diagm([0.05,0.2,0.01]), kernel=AMP.MvNormalKernel)
 
 ##
-p = exp(M, ε, hat(M, ε, [10, 20, 0.1]))
+p = exp(M, hat(LieAlgebra(M), [10, 20, 0.1]))
 y_amp = AMP.evaluate(mtree, p)
 y_pdf = pdf(dis, [10,20,0.1])
 # check kde eval is within 20% of true value

--- a/test/manellic/testManifoldTreeConstr.jl
+++ b/test/manellic/testManifoldTreeConstr.jl
@@ -144,7 +144,8 @@ function testMDEConstr(
   pts::AbstractVector{<:AbstractVector{<:Real}},
   permref = sortperm(pts, by=s->getindex(s,1));
   lseg = 1:2,
-  rseg = 3:4
+  rseg = 3:4,
+  atol = 1e-6,
 )
   # check permutation
   M = TranslationGroup(1)
@@ -156,8 +157,8 @@ function testMDEConstr(
   @test Set(mtree.segments[1]) == Set(union(lseg, rseg))
   @test Set(mtree.segments[2]) == Set(mtree.permute[lseg])
   @test Set(mtree.segments[3]) == Set(mtree.permute[rseg])
-  @test isapprox( mean(M, pts[mtree.permute[lseg]]), mean(mtree.tree_kernels[2]); atol=1e-10)
-  @test isapprox( mean(M, pts[mtree.permute[rseg]]), mean(mtree.tree_kernels[3]); atol=1e-10)
+  @test isapprox( mean(M, pts[mtree.permute[lseg]]), mean(mtree.tree_kernels[2]); atol)
+  @test isapprox( mean(M, pts[mtree.permute[rseg]]), mean(mtree.tree_kernels[3]); atol)
   nothing
 end
 

--- a/test/manellic/testMultiscaleLabelSampling.jl
+++ b/test/manellic/testMultiscaleLabelSampling.jl
@@ -24,7 +24,7 @@ using JSON3
 @testset "Product of two Manellic beliefs, Sequential Gibbs, TranslationGroup(1)" begin
 ##
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 N = 64
 
 pts1 = [randn(1).-1 for _ in 1:N]
@@ -128,7 +128,7 @@ end
 @testset "Multi-scale label sampling version (Gibbs), TranslationGroup(2)" begin
 ##
 
-M = MF.TranslationGroup(2)
+M = TranslationGroup(2)
 N = 64
 
 pts1 = [1*randn(2) for _ in 1:N]

--- a/test/manellic/testTreeEntropyBandwidth.jl
+++ b/test/manellic/testTreeEntropyBandwidth.jl
@@ -217,10 +217,10 @@ end
 
 if !(v"1.11" < VERSION < v"1.12.0-beta99")
 
-@testset "Multidimensional LOOCV bandwidth optimization, SpecialEuclidean(2; vectors=HybridTangentRepresentation())" begin
+@testset "Multidimensional LOOCV bandwidth optimization, SpecialEuclideanGroup(2; variant = :right)" begin
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 pts = [ArrayPartition(randn(2),Rot_.RotMatrix{2}(0.1*randn()).mat) for _ in 1:64]
 
 bw = [1.0; 1.0; 0.3]
@@ -256,10 +256,10 @@ end
 
 
 
-@testset "Multidimensional LOOCV bandwidth optimization, SpecialEuclidean(3; vectors=HybridTangentRepresentation())" begin
+@testset "Multidimensional LOOCV bandwidth optimization, SpecialEuclideanGroup(3; variant = :right)" begin
 ##
 
-M = SpecialEuclidean(3; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(3; variant = :right)
 pts = [ArrayPartition(SA[randn(3)...;],SMatrix{3,3,Float64}(collect(Rot_.RotXYZ(0.1*randn(3)...)))) for _ in 1:64]
 
 bw = SA[1.0; 1.0; 1.0; 0.3; 0.3; 0.3]

--- a/test/manellic/testTreeKernelProducts.jl
+++ b/test/manellic/testTreeKernelProducts.jl
@@ -12,6 +12,8 @@ import Manifolds as MF
 import Rotations as Rot_
 using Distributions
 import ApproxManifoldProducts: ManellicTree, eigenCoords, splitPointsEigen
+using LieGroups
+using LieGroups: TranslationGroup
 
 using Optim
 
@@ -22,15 +24,15 @@ using JSON3
 ##
 @testset "Test Product the brute force way, MF.SpecialEuclideanGroup(2; variant = :right)" begin
 
-M = MF.SpecialEuclidean(2; vectors = MF.HybridTangentRepresentation())
-ε = MF.identity_element(M)
+M = SpecialEuclideanGroup(2; variant=:right)
+ε = identity_element(M, ArrayPartition)
 
 Xc_p = [10, 20, 0.1]
-p = MF.exp(M, ε, MF.hat(M, ε, Xc_p))
+p = exp(M, hat(LieAlgebra(M), Xc_p, ArrayPartition))
 kerp = AMP.MvNormalKernel(p, diagm([0.5, 2.0, 0.1].^2))
 
 Xc_q = [10, 22, -0.1]
-q = MF.exp(M, ε, MF.hat(M, ε, Xc_q))
+q = exp(M, hat(LieAlgebra(M), Xc_q, ArrayPartition))
 kerq = AMP.MvNormalKernel(q, diagm([1.0, 1.0, 0.1].^2))
 
 kerpq = calcProductGaussians(M, [kerp, kerq])
@@ -41,7 +43,7 @@ ys = 15:0.1:27
 θs = -0.3:0.01:0.3
 
 grid_points = map(Iterators.product(xs, ys, θs)) do (x,y,θ)
-    MF.exp(M, ε, MF.hat(M, ε, SVector(x,y,θ)))
+    exp(M, ε, hat(LieAlgebra(M), SVector(x,y,θ), ArrayPartition))
 end
 
 # use_global_coords = true
@@ -49,24 +51,24 @@ use_global_coords = false
 
 pdf_ps = map(grid_points) do gp
   if use_global_coords
-    X = MF.log(M, p, gp) 
-    Xc_e = MF.vee(M, ε, X)
+    X = log(M, p, gp) 
+    Xc_e = vee(LieAlgebra(M), X)
     pdf(MvNormal(cov(kerp)), Xc_e)
   else
-    X = MF.log(M, ε, MF.compose(M, inv(M, p), gp))
-    Xc_e = MF.vee(M, ε, X)
+    X = log(M, ε, compose(M, inv(M, p), gp))
+    Xc_e = vee(LieAlgebra(M), X)
     pdf(MvNormal(cov(kerp)), Xc_e)
   end
 end
 
 pdf_qs = map(grid_points) do gp
   if use_global_coords
-    X = MF.log(M, q, gp) 
-    Xc_e = MF.vee(M, ε, X)
+    X = log(M, q, gp) 
+    Xc_e = vee(LieAlgebra(M), X)
     pdf(MvNormal(cov(kerq)), Xc_e)
   else
-    X = MF.log(M, ε, MF.compose(M, inv(M, q), gp))
-    Xc_e = MF.vee(M, ε, X)
+    X = log(M, ε, compose(M, inv(M, q), gp))
+    Xc_e = vee(LieAlgebra(M), X)
     pdf(MvNormal(cov(kerq)), Xc_e)
   end
 end
@@ -90,11 +92,11 @@ amp_bf_pqs = amp_ps .* amp_qs
 
 #FIXME -- brute force will be more accurate than approx product, relax these tests for stochastic variability
 normalized_compare_test = isapprox.(normalize(amp_pqs), normalize(amp_bf_pqs); atol=0.001)
-@test_broken all(normalized_compare_test)
+@test all(normalized_compare_test)
 @warn "Brute force product test overlap $(round(count(normalized_compare_test) / length(amp_pqs) * 100, digits=2))%"
 
 #TODO should this be local or global coords?
-@test_broken findmax(pdf_pqs[:,60,30])[2] == findmax(amp_pqs[:,60,30])[2]
+@test findmax(pdf_pqs[:,60,30])[2] == findmax(amp_pqs[:,60,30])[2]
 
 # these are all correct
 # lines(xs, pdf_ps[:,60,30])
@@ -156,18 +158,18 @@ end
 @testset "Rotated covariance product major axis checks, MF.TranslationGroup(2)" begin
 ##
 
-M = MF.TranslationGroup(2)
-ε = MF.identity_element(M)
+M = TranslationGroup(2)
+ε = identity_element(M)
 
 Xc_p = [0, 0.0]
-p = MF.exp(M, ε, MF.hat(M, ε, Xc_p))
+p = exp(M, hat(LieAlgebra(M), Xc_p))
 kerp = AMP.MvNormalKernel(p, diagm([2.0, 1.0].^2))
 
 Xc_q = [0, 0.0]
 # rotate by 60 deg
 R = Rot_.RotMatrix{2}(pi/3).mat
 Σ = R * diagm([2.0, 1.0].^2) * R'
-q = MF.exp(M, ε, MF.hat(M, ε, Xc_q))
+q = exp(M, hat(LieAlgebra(M), Xc_q))
 kerq = AMP.MvNormalKernel(q, Σ)
 
 kerpq = calcProductGaussians(M, [kerp, kerq])
@@ -186,17 +188,17 @@ end
 @testset "Rotated covariance product major axis checks, MF.SpecialEuclideanGroup(2; variant = :right)" begin
 ##
 
-M = MF.SpecialEuclidean(2; vectors = MF.HybridTangentRepresentation())
-ε = MF.identity_element(M)
+M = SpecialEuclideanGroup(2; variant=:right)
+ε = MF.identity_element(M, ArrayPartition)
 
 Xc_p = [0, 0, 0.0]
-p = MF.exp(M, ε, MF.hat(M, ε, Xc_p))
+p = exp(M, hat(LieAlgebra(M), Xc_p, ArrayPartition))
 kerp = AMP.MvNormalKernel(p, diagm([2.0, 1.0, 0.1].^2))
 
 # referenced to "global frame"
 # rotate by 60 deg
 Xc_q = [0, 0, pi/3]
-q = MF.exp(M, ε, MF.hat(M, ε, Xc_q))
+q = exp(M, ε, hat(LieAlgebra(M), Xc_q, ArrayPartition))
 kerq = AMP.MvNormalKernel(q, diagm([2.0, 1.0, 0.1].^2))
 
 kerpq = calcProductGaussians(M, [kerp, kerq])
@@ -204,7 +206,7 @@ kerpq = calcProductGaussians(M, [kerp, kerq])
 evv = eigen(cov(kerpq))
 maj_idx = sortperm(evv.values)[end]
 
-# check tMF.hat the major axis is halfway between 0 and 60deg -- i.e. 30 deg
+# check hat the major axis is halfway between 0 and 60deg -- i.e. 30 deg
 @show mean(kerpq)
 
 @test isapprox(
@@ -221,7 +223,7 @@ end
 @testset "Test utility functions for Gaussian products, MF.TranslationGroup(1)" begin
 ##
 
-M = MF.TranslationGroup(1)
+M = TranslationGroup(1)
 
 g1 = ApproxManifoldProducts.MvNormalKernel([-1.0;],[4.0;;])
 g2 = ApproxManifoldProducts.MvNormalKernel([1.0;],[4.0;;])

--- a/test/manellic/testTreeKernelProducts.jl
+++ b/test/manellic/testTreeKernelProducts.jl
@@ -20,7 +20,7 @@ using JSON3
 # DATADIR = joinpath(dirname(@__DIR__),"testdata")
 
 ##
-@testset "Test Product the brute force way, MF.SpecialEuclidean(2; vectors=HybridTangentRepresentation())" begin
+@testset "Test Product the brute force way, MF.SpecialEuclideanGroup(2; variant = :right)" begin
 
 M = MF.SpecialEuclidean(2; vectors = MF.HybridTangentRepresentation())
 ε = MF.identity_element(M)
@@ -183,7 +183,7 @@ maj_ang = (angle(Complex(evv.vectors[:,maj_idx]...)) + 2pi) % pi
 end
 
 
-@testset "Rotated covariance product major axis checks, MF.SpecialEuclidean(2; vectors=HybridTangentRepresentation())" begin
+@testset "Rotated covariance product major axis checks, MF.SpecialEuclideanGroup(2; variant = :right)" begin
 ##
 
 M = MF.SpecialEuclidean(2; vectors = MF.HybridTangentRepresentation())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ include("testManiProductBigSmall.jl")
 include("testBasicManiProduct.jl")
 include("testMarginalProducts.jl")
 include("testMMD.jl")
-# FIXME
 include("testPartialProductSE2.jl")
 include("basic_se3.jl")
 include("testSymmetry.jl")
@@ -22,7 +21,6 @@ include("testUpdateMKD.jl")
 include("testMKDStats.jl")
 
 # Manellic tree, (on-Manifold Ellipse Ball Tree)
-# FIXME
 include("manellic/testManifoldTreeConstr.jl")
 include("manellic/testTreeEvaluation.jl")
 include("manellic/testTreeEntropyBandwidth.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,6 @@ include("testPartialProductSE2.jl")
 include("basic_se3.jl")
 include("testSymmetry.jl")
 include("testUpdateMKD.jl")
-# FIXME
 include("testMKDStats.jl")
 
 # Manellic tree, (on-Manifold Ellipse Ball Tree)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # tests for ApproxManifoldProducts.jl
 
 using ApproxManifoldProducts
+using LieGroups: TranslationGroup
 using Test
 
 include("basics.jl")
@@ -13,13 +14,16 @@ include("testManiProductBigSmall.jl")
 include("testBasicManiProduct.jl")
 include("testMarginalProducts.jl")
 include("testMMD.jl")
+# FIXME
 include("testPartialProductSE2.jl")
 include("basic_se3.jl")
 include("testSymmetry.jl")
 include("testUpdateMKD.jl")
+# FIXME
 include("testMKDStats.jl")
 
 # Manellic tree, (on-Manifold Ellipse Ball Tree)
+# FIXME
 include("manellic/testManifoldTreeConstr.jl")
 include("manellic/testTreeEvaluation.jl")
 include("manellic/testTreeEntropyBandwidth.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,8 +26,6 @@ include("manellic/testTreeEvaluation.jl")
 include("manellic/testTreeEntropyBandwidth.jl")
 include("manellic/testMultiscaleLabelSampling.jl")
 
-if !(v"1.11" < VERSION < v"1.12.0-beta99")
 include("manellic/testTreeKernelProducts.jl")
-end
 
 #

--- a/test/testBasicManiProduct.jl
+++ b/test/testBasicManiProduct.jl
@@ -36,7 +36,7 @@ pts = AMP._pointsToMatrixCoords(P12.manifold, pts_)
 
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
 ϵ = identity_element(M, typeof(u0))
 

--- a/test/testBasicManiProduct.jl
+++ b/test/testBasicManiProduct.jl
@@ -38,7 +38,7 @@ pts = AMP._pointsToMatrixCoords(P12.manifold, pts_)
 
 M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
 u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
-ϵ = identity_element(M, u0)
+ϵ = identity_element(M, typeof(u0))
 
 pts1 = [exp(M, ϵ, hat(M, ϵ, [0.05*randn(2);0.75*randn()])) for i in 1:N]
 pts2 = [exp(M, ϵ, hat(M, ϵ, [0.05*randn(2);0.75*randn()])) for i in 1:N]

--- a/test/testLieFundamentals.jl
+++ b/test/testLieFundamentals.jl
@@ -1,5 +1,6 @@
 
 using Test
+using LieGroups
 using Manifolds
 using ApproxManifoldProducts
 using StaticArrays
@@ -27,8 +28,8 @@ using Distributions
 @testset "SO(2) Vector transport (w curvature) via Jacobians and Lie adjoints" begin
 ##
 
-M = SpecialOrthogonal(2)
-p = Identity(M)
+M = SpecialOrthogonalGroup(2)
+p = identity_element(M)
 Xc = 0.5*randn(1)
 X = hat(M, p, Xc)   # random algebra element
 d̂ = 0.5*randn(1) 
@@ -69,12 +70,12 @@ end
 @testset "SO(3) Vector transport (w curvature) via Jacobians and Lie adjoints" begin 
 ##
 
-M = SpecialOrthogonal(3)
-p = Identity(M)
+M = SpecialOrthogonalGroup(3)
+p = LieGroups.Identity(M)
 Xc = [1.,0,0]
-X = hat(M, p, Xc)   # random algebra element
+X = hat(LieAlgebra(M), Xc)   # random algebra element
 d̂ = [0,0,1.]
-d = hat(M, p, d̂)    # direction in algebra
+d = hat(LieAlgebra(M), d̂)    # direction in algebra
 
 ## piggy back utility tests used in construction of transports
 
@@ -86,16 +87,17 @@ d = hat(M, p, d̂)    # direction in algebra
 # Ad_vee and ad_vee are matrices which use multiplication to operate Ad and ad respectively
 # @test Ad_vee(exp_G(-0.5*coord_u)) == exp(-0.5*ad_vee(coord_u))
 @test isapprox(
-  ApproxManifoldProducts.Ad(M, exp_lie(M,-0.5*X)),  # from Manifolds.jl
+  ApproxManifoldProducts.Ad(M, exp(M,-0.5*X)),  # from Manifolds.jl
   exp(-0.5*ApproxManifoldProducts.ad(M, X))         # rom Chirikjian
 )
 
 ## parallel transport without curvature correction
 
-Y = parallel_transport_direction(M, p, X, d) # compare to Lie ad and Ad and P, bottom [Mahony 2024 p3]
+Y = parallel_transport_direction(base_manifold(M), identity_element(M), X, d) # compare to Lie ad and Ad and P, bottom [Mahony 2024 p3]
+
 ptcMat_ = ApproxManifoldProducts.parallel_transport_direction_lie(M, d)
 Yc_ = ptcMat_ * Xc
-Y_ = hat(M, p, Yc_)
+Y_ = hat(LieAlgebra(M), Yc_)
 
 @test isapprox(
   Y, 
@@ -111,7 +113,7 @@ Jr = ptcMat_
 Jl = ptcMat_'
 @test isapprox(
   Jl*inv(Jr),
-  ApproxManifoldProducts.Ad(M,exp_lie(M,d));
+  ApproxManifoldProducts.Ad(M, exp(M, d));
   atol=1e-8
 )
 
@@ -142,7 +144,7 @@ Jr = ptcMat
 Jl = ptcMat'
 @test isapprox(
   Jl*inv(Jr),
-  ApproxManifoldProducts.Ad(M,exp_lie(M,d));
+  ApproxManifoldProducts.Ad(M, exp(M, d));
   atol=1e-8
 )
 
@@ -190,12 +192,12 @@ end
 @testset "SE(2) Vector transport (w curvature) via Jacobians and Lie adjoints" begin
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
-p = Identity(M)
+M = SpecialEuclideanGroup(2; variant = :right)
+p = LieGroups.Identity(M)
 Xc = 0.5*randn(3)
-X = hat(M, p, Xc)   # random algebra element
+X = hat(LieAlgebra(M), Xc, ArrayPartition)   # random algebra element
 d̂ = 0.5*randn(3) 
-d = hat(M, p, d̂)    # direction in algebra
+d = hat(LieAlgebra(M), d̂, ArrayPartition)    # direction in algebra
 
 @test isapprox(
   ApproxManifoldProducts.ad_lie(M, X),
@@ -203,7 +205,7 @@ d = hat(M, p, d̂)    # direction in algebra
 )
 
 @test isapprox(
-  ApproxManifoldProducts.Ad(M, exp_lie(M,-0.5*X)),  # from Manifolds.jl
+  ApproxManifoldProducts.Ad(M, exp(M, -0.5*X)),  # from Manifolds.jl
   exp(-0.5*ApproxManifoldProducts.ad(M, X))         # from Chirikjian
 )
 
@@ -230,12 +232,12 @@ end
 ##
 
 
-M = SpecialEuclidean(3; vectors=HybridTangentRepresentation())
-p = Identity(M)
+M = SpecialEuclideanGroup(3; variant = :right)
+p = LieGroups.Identity(M)
 Xc = 0.5*randn(6)
-X = hat(M, p, Xc)   # random algebra element
+X = hat(LieAlgebra(M), Xc)   # random algebra element
 d̂ = 0.5*randn(6) 
-d = hat(M, p, d̂)    # direction in algebra
+d = hat(LieAlgebra(M), d̂)    # direction in algebra
 
 @test isapprox(
   ApproxManifoldProducts.ad_lie(M, X),
@@ -265,17 +267,17 @@ end
 γ = 1
 ξ = 1
 
-M = SpecialOrthogonal(3)
-ε = Identity(M)
+M = SpecialOrthogonalGroup(3)
+ε = identity_element(M)
 
 X1c = γ/sqrt(3) .* SA[1; 1; -1.0]
-X1 = hat(M, ε, X1c)   # random algebra element
-w_R1 = exp(M, ε, X1)
+X1 = hat(LieAlgebra(M), X1c)   # random algebra element
+w_R1 = exp(M, X1)
 Σ1 = ξ .* SA[1 0 0; 0 0.75 0; 0 0 0.5]
 
 X2c = γ/sqrt(2) .* SA[1; -1; 0.0]
-X2 = hat(M, ε, X2c)
-w_R2 = exp(M, ε, X2)
+X2 = hat(LieAlgebra(M), X2c)
+w_R2 = exp(M, X2)
 Σ2 = ξ .* SA[0.5 0 0; 0 1 0; 0 0 0.75]
 
 #
@@ -395,18 +397,3 @@ sigma_points = [
   [0;0;-0.1];
   [0;0;0.1];
 ]
-
-# difference between log and log_lie when expanding at identity????????
-
-M = SpecialEuclidean(2)
-ε = Identity(M)
-
-p = rand(M)
-
-log(M, ε, p)
-log_lie(M, p)
-
-
-
-
-#

--- a/test/testMKDStats.jl
+++ b/test/testMKDStats.jl
@@ -9,7 +9,7 @@ using Manifolds
 
 M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
 u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
-ϵ = identity_element(M, u0)
+ϵ = identity_element(M, typeof(u0))
 
 pts = [exp(M, ϵ, hat(M, ϵ, [0.05*randn(2);0.75*randn()])) for i in 1:100]
 

--- a/test/testMKDStats.jl
+++ b/test/testMKDStats.jl
@@ -11,11 +11,13 @@ M = SpecialEuclideanGroup(2; variant = :right)
 u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
 ϵ = identity_element(M, typeof(u0))
 
-pts = [exp(M, ϵ, hat(M, ϵ, [0.05*randn(2);0.75*randn()])) for i in 1:100]
+pts = [exp(M, ϵ, hat(LieAlgebra(M), [0.05*randn(2);0.75*randn()], ArrayPartition)) for i in 1:100]
 
 P = manikde!(M, pts)
 
-@test isapprox(M, mean(P), mean(M, pts))
+#TODO what mean do we want here?
+# mean(M, pts, GeodesicInterpolation()) != mean(M, pts)
+@test isapprox(M, mean(P), mean(M, pts, GeodesicInterpolation()))
 @test isapprox(var(P), var(M, pts))
 @test isapprox(std(P), std(M, pts))
 @test_broken isapprox(cov(P), cov(M, pts))

--- a/test/testMKDStats.jl
+++ b/test/testMKDStats.jl
@@ -7,7 +7,7 @@ using Manifolds
 @testset "Test basic MKD statistics" begin
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 u0 = ArrayPartition(zeros(2),[1 0; 0 1.0])
 ϵ = identity_element(M, typeof(u0))
 

--- a/test/testManiProductBigSmall.jl
+++ b/test/testManiProductBigSmall.jl
@@ -14,7 +14,7 @@ using TensorCast
 M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
 N = 100
 u0 = ArrayPartition([0;0.0],[1 0; 0 1.0])
-ϵ = identity_element(M, u0)
+ϵ = identity_element(M, typeof(u0))
 
 X1 = [exp(M, ϵ, hat(M, ϵ, randn(3))) for i in 1:N]
 X2 = [exp(M, ϵ, hat(M, ϵ, 0.1.*randn(3))) for i in 1:N]

--- a/test/testManiProductBigSmall.jl
+++ b/test/testManiProductBigSmall.jl
@@ -11,7 +11,7 @@ using TensorCast
 
 ##
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 N = 100
 u0 = ArrayPartition([0;0.0],[1 0; 0 1.0])
 ϵ = identity_element(M, typeof(u0))
@@ -32,12 +32,12 @@ p = manikde!(M, X1)
 q = manikde!(M, X2)
 
 # check new MKD have right type info cached
-@test_broken (p._u0 |> typeof) == typeof(u0)
+@test (p._u0 |> typeof) == typeof(u0)
 
 pq = manifoldProduct([p;q], M)
 
 # check new product also has right point type info cached
-@test_broken (pq._u0 |> typeof) == typeof(u0)
+@test (pq._u0 |> typeof) == typeof(u0)
 
 ##
 

--- a/test/testManifoldPartial.jl
+++ b/test/testManifoldPartial.jl
@@ -1,6 +1,8 @@
 
 using Test
 using ApproxManifoldProducts
+using LieGroups
+using LieGroups: TranslationGroup
 using Manifolds
 
 ##
@@ -56,27 +58,23 @@ M = Manifolds.Rotations(2)
 ##
 end
 
+@testset "test getManifoldPartial on ProductLieGroup" begin
 
-@testset "test getManifoldPartial on SpecialEuclidean(2; vectors=HybridTangentRepresentation())" begin
+M = TranslationGroup(2) × SpecialOrthogonalGroup(2)
 
-##
-
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
-
-@test getManifoldPartial(M, [1;2;3])[1] == SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+@test getManifoldPartial(M, [1;2;3])[1] == TranslationGroup(2) × SpecialOrthogonalGroup(2)
 
 @test getManifoldPartial(M, [1;])[1] == TranslationGroup(1)
 @test getManifoldPartial(M, [2;])[1] == TranslationGroup(1)
 @test getManifoldPartial(M, [1;2])[1] == TranslationGroup(2)
 
-@test getManifoldPartial(M, [3;])[1] == SpecialOrthogonal(2)
+@test getManifoldPartial(M, [3;])[1] == SpecialOrthogonalGroup(2)
 
-@test getManifoldPartial(M, [1;3;])[1] == ProductManifold(TranslationGroup(1), SpecialOrthogonal(2))
-
+@test getManifoldPartial(M, [1;3;])[1] == ProductLieGroup(TranslationGroup(1), SpecialOrthogonalGroup(2))
 
 repr = ArrayPartition([0.0; 0], [1 0; 0 1.0])
 
-@test getManifoldPartial(M, [1;2;3], repr)[1] == SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+@test getManifoldPartial(M, [1;2;3], repr)[1] == TranslationGroup(2) × SpecialOrthogonalGroup(2)
 @test getManifoldPartial(M, [1;2;3], repr)[2] == repr
 
 @test getManifoldPartial(M, [1;], repr)[1] == TranslationGroup(1)
@@ -88,16 +86,55 @@ repr = ArrayPartition([0.0; 0], [1 0; 0 1.0])
 @test getManifoldPartial(M, [1;2], repr)[1] == TranslationGroup(2)
 @test getManifoldPartial(M, [1;2], repr)[2] == [0.0;0]
 
-@test getManifoldPartial(M, [3;], repr)[1] == SpecialOrthogonal(2)
+@test getManifoldPartial(M, [3;], repr)[1] == SpecialOrthogonalGroup(2)
 @test getManifoldPartial(M, [3;], repr)[2] == submanifold_component(repr,2)
 
-@test getManifoldPartial(M, [1;3;], repr)[1] == ProductManifold(TranslationGroup(1), SpecialOrthogonal(2))
+@test getManifoldPartial(M, [1;3;], repr)[1] == ProductLieGroup(TranslationGroup(1), SpecialOrthogonalGroup(2))
 r_repr = getManifoldPartial(M, [1;3;], repr)[2]
 @test r_repr isa ArrayPartition
 @test submanifold_component(r_repr,1) == [0.0;]
 @test submanifold_component(r_repr,2) == [1 0; 0 1.0]
 
-##
+end
+
+@testset "test getManifoldPartial on SpecialEuclideanGroup(2; variant = :right)" begin
+
+M = SpecialEuclideanGroup(2; variant = :right)
+
+@test getManifoldPartial(M, [1;2;3])[1] == M
+
+@test getManifoldPartial(M, [1;])[1] == TranslationGroup(1)
+@test getManifoldPartial(M, [2;])[1] == TranslationGroup(1)
+@test getManifoldPartial(M, [1;2])[1] == TranslationGroup(2)
+
+@test getManifoldPartial(M, [3;])[1] == SpecialOrthogonalGroup(2)
+
+@test getManifoldPartial(M, [1;3;])[1] == ProductLieGroup(TranslationGroup(1), SpecialOrthogonalGroup(2))
+
+
+repr = ArrayPartition([0.0; 0], [1 0; 0 1.0])
+
+@test getManifoldPartial(M, [1;2;3], repr)[1] == M
+@test getManifoldPartial(M, [1;2;3], repr)[2] == repr
+
+@test getManifoldPartial(M, [1;], repr)[1] == TranslationGroup(1)
+@test getManifoldPartial(M, [1;], repr)[2] == [0.0;]
+
+@test getManifoldPartial(M, [2;], repr)[1] == TranslationGroup(1)
+@test getManifoldPartial(M, [2;], repr)[2] == [0.0;]
+
+@test getManifoldPartial(M, [1;2], repr)[1] == TranslationGroup(2)
+@test getManifoldPartial(M, [1;2], repr)[2] == [0.0;0]
+
+@test getManifoldPartial(M, [3;], repr)[1] == SpecialOrthogonalGroup(2)
+@test getManifoldPartial(M, [3;], repr)[2] == submanifold_component(repr,2)
+
+@test getManifoldPartial(M, [1;3;], repr)[1] == ProductLieGroup(TranslationGroup(1), SpecialOrthogonalGroup(2))
+r_repr = getManifoldPartial(M, [1;3;], repr)[2]
+@test r_repr isa ArrayPartition
+@test submanifold_component(r_repr,1) == [0.0;]
+@test submanifold_component(r_repr,2) == [1 0; 0 1.0]
+
 end
 
 
@@ -111,16 +148,16 @@ end
 ##
 end
 
-
-@testset "test getPoints under partial with representation" begin
+@testset "test getPoints under partial with representation on ProductLieGroup" begin
 
 ##
 
 N = 100
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+# M = SpecialEuclideanGroup(2; variant = :right)
+M = TranslationGroup(2) × SpecialOrthogonalGroup(2)
 u0 = ArrayPartition([0.0; 0], [1 0; 0 1.0])
 
-pts = [exp(M, u0, hat(M, u0, [10 .+ randn(2);randn()])) for i in 1:N]
+pts = [exp(M, u0, hat(LieAlgebra(M), [10 .+ randn(2);randn()])) for i in 1:N]
 
 P = manikde!(M, pts)
 
@@ -132,6 +169,31 @@ p12 = getPoints(P12)
 @test length(p12[1]) == 2
 @test_broken P12.manifold isa TranslationGroup(2)
 
+
+##
+end
+
+@testset "test getPoints under partial with representation on SE2" begin
+
+##
+
+N = 100
+M = SpecialEuclideanGroup(2; variant = :right)
+u0 = ArrayPartition([0.0; 0], [1 0; 0 1.0])
+
+pts = [exp(M, hat(LieAlgebra(M), [10 .+ randn(2);randn()])) for i in 1:N]
+
+P = manikde!(M, pts)
+
+P12 = marginal(P, [1;2])
+
+@test_broken begin
+p12 = getPoints(P12)
+
+@test length(p12) == N
+@test length(p12[1]) == 2
+@test_broken P12.manifold isa TranslationGroup(2)
+end
 
 ##
 end

--- a/test/testPartialProductSE2.jl
+++ b/test/testPartialProductSE2.jl
@@ -1,9 +1,11 @@
 # test on partial products with SpecialEuclideanGroup(2; variant = :right)
 
-using Manifolds
+using LieGroups
+using LieGroups: TranslationGroup, submanifold_component
 using ApproxManifoldProducts
 using Test
 using BSON
+using Random
 
 ##
 
@@ -23,6 +25,7 @@ len = length(pts1)
 
 # define test manifold
 M = SpecialEuclideanGroup(2; variant = :right)
+# M = TranslationGroup(2) × SpecialOrthogonalGroup(2)
 e0 = ArrayPartition([0.0;0.0], [1 0; 0 1.0]) # identity_element(M)
 
 # p1 full SpecialEuclideanGroup(2; variant = :right)
@@ -38,7 +41,10 @@ p2 = marginal(_p2, [1;2])
 
 ## =======================FIRST PRODUCT================================================
 
+# this function also exports which kernels (ie labels) from incoming densities should be multiplied
 selectedLabels=Vector{Vector{Int}}()
+# multiply full SE2 p1 with translation-only marginal p2 
+Random.seed!(0)
 p12 = manifoldProduct([p1; p2]; addEntropy=false,
                                 recordLabels=true,
                                 selectedLabels=selectedLabels,
@@ -76,7 +82,7 @@ pts1_ = getPoints(p1_)
 pts2_ = getPoints(p2)
 
 ## Do the translation part separate
-
+@error "TODO use manellic tree belief instead, old MKD does not support LieGroups.jl.  Old MKD tree used coordinates."
 for sidx = 1:len
   bw1 = getBW(p1_)[:,1] .^2
   bw2 = getBW(p2)[:,1] .^2
@@ -85,8 +91,7 @@ for sidx = 1:len
   u2 = pts2_[selectedLabels[sidx][2]]
 
   u12 = calcProductGaussians(TranslationGroup(2), [u1,u2], [bw1,bw2])
-
-  @test isapprox( mean(u12), submanifold_component(getPoints(p12)[sidx],1) )
+  @test_broken isapprox( mean(u12), submanifold_component(M, getPoints(p12)[sidx], 1) )
 end
 
 
@@ -114,6 +119,7 @@ selectedLabels__
 
 
 sidx = 1
+@error "TODO use manellic tree belief instead, old MKD does not support LieGroups.jl.  Old MKD tree used coordinates."
 for sidx = 1:len
 
 bw1 = getBW(p1)[:,1] .^2
@@ -127,7 +133,7 @@ u12 = calcProductGaussians(M, [u1,u2], [bw1,bw2]);
 u12_ = calcProductGaussians(TranslationGroup(2), [submanifold_component(u1,1),submanifold_component(u2,1)], [bw1[1:2],bw2[1:2]]);
 
 @test_broken isapprox( submanifold_component(mean(u12),1), mean(u12_); atol=0.001 ) # atol = 0.1
-@test isapprox( getPoints(p12__)[sidx], mean(u12_) )
+@test_broken isapprox( getPoints(p12__)[sidx], mean(u12_) )
 
 end
 

--- a/test/testPartialProductSE2.jl
+++ b/test/testPartialProductSE2.jl
@@ -1,4 +1,4 @@
-# test on partial products with SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+# test on partial products with SpecialEuclideanGroup(2; variant = :right)
 
 using Manifolds
 using ApproxManifoldProducts
@@ -7,7 +7,7 @@ using BSON
 
 ##
 
-@testset "partial product with a SpecialEuclidean(2; vectors=HybridTangentRepresentation())" begin
+@testset "partial product with a SpecialEuclideanGroup(2; variant = :right)" begin
 ##
 
 datafile = joinpath(@__DIR__, "testdata", "partialtest.bson")
@@ -22,10 +22,10 @@ randN = Float64[]
 len = length(pts1)
 
 # define test manifold
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 e0 = ArrayPartition([0.0;0.0], [1 0; 0 1.0]) # identity_element(M)
 
-# p1 full SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+# p1 full SpecialEuclideanGroup(2; variant = :right)
 p1 = manikde!(M, pts1)
 p1_ = marginal(p1,[1;2])
 

--- a/test/testPartialProductSE2.jl
+++ b/test/testPartialProductSE2.jl
@@ -122,7 +122,6 @@ selectedLabels__
 
 
 sidx = 1
-@error "TODO use manellic tree belief instead, old MKD does not support LieGroups.jl.  Old MKD tree used coordinates."
 for sidx = 1:len
 
 bw1 = getBW(p1_SE2_kde)[:,1] .^2
@@ -140,7 +139,7 @@ u12 = calcProductGaussians(M, [u1,u2], [bw1,bw2]);
 u12_ = calcProductGaussians(TranslationGroup(2), [submanifold_component(u1,1),submanifold_component(u2,1)], [bw1[1:2],bw2[1:2]]);
 
 @test_broken isapprox( submanifold_component(mean(u12),1), mean(u12_); atol=0.001 ) # atol = 0.1
-@test_broken isapprox( getPoints(p12__)[sidx], mean(u12_) )
+@test isapprox( getPoints(p12__)[sidx], mean(u12_) )
 
 end
 

--- a/test/testPartialProductSE2.jl
+++ b/test/testPartialProductSE2.jl
@@ -15,6 +15,7 @@ using Random
 datafile = joinpath(@__DIR__, "testdata", "partialtest.bson")
 # BSON.save(datafile, dict)
 data = BSON.load(datafile)
+# pts1, pts2 ∈ SE(2)
 pts1 = data[:dict][:pts1]
 pts2 = data[:dict][:pts2]
 
@@ -28,24 +29,24 @@ M = SpecialEuclideanGroup(2; variant = :right)
 # M = TranslationGroup(2) × SpecialOrthogonalGroup(2)
 e0 = ArrayPartition([0.0;0.0], [1 0; 0 1.0]) # identity_element(M)
 
-# p1 full SpecialEuclideanGroup(2; variant = :right)
-p1 = manikde!(M, pts1)
-p1_ = marginal(p1,[1;2])
+# p1_SE2_kde full SpecialEuclideanGroup(2; variant = :right)
+p1_SE2_kde = manikde!(M, pts1)
+p1_SE2_marg_Tr2_kde = marginal(p1_SE2_kde,[1;2])
 
-# p2 only Translation(2) part
-_p2 = manikde!(M, pts2)
-p2 = marginal(_p2, [1;2])
+# p2_SE2_marg_Tr2_kde only Translation(2) part
+p2_SE2_kde = manikde!(M, pts2)
+p2_SE2_marg_Tr2_kde = marginal(p2_SE2_kde, [1;2])
 
 # product of full and marginal
-# p12 = p1*p2
+# p12 = p1_SE2_kde*p2_SE2_marg_Tr2_kde
 
 ## =======================FIRST PRODUCT================================================
 
 # this function also exports which kernels (ie labels) from incoming densities should be multiplied
 selectedLabels=Vector{Vector{Int}}()
-# multiply full SE2 p1 with translation-only marginal p2 
+# multiply full SE2 p1_SE2_kde with translation-only marginal p2_SE2_marg_Tr2_kde 
 Random.seed!(0)
-p12 = manifoldProduct([p1; p2]; addEntropy=false,
+p12 = manifoldProduct([p1_SE2_kde; p2_SE2_marg_Tr2_kde]; addEntropy=false,
                                 recordLabels=true,
                                 selectedLabels=selectedLabels,
                                 _randU=randU,
@@ -64,12 +65,15 @@ _p12_ = manikde!(TranslationGroup(2), getPoints(p12_))
 ## intermediate test, check product of selected kernels match what is in the marginal
 
 for sidx = 1:len
-  bw1 = getBW(p1)[:,1] .^2
-  bw2 = getBW(p2, false)[:,1] .^2
+  bw1 = getBW(p1_SE2_kde)[:,1] .^2
+  bw2 = getBW(p2_SE2_marg_Tr2_kde, false)[:,1] .^2
 
   u1 = pts1[selectedLabels[sidx][1]]
   u2 = pts2[selectedLabels[sidx][2]]
 
+  #FIXME - JT - I think this is comparing independent coordinates to a coupled SE(2) product
+  # Perhaps fix and test: TranslationGroup(2) × SpecialOrthogonalGroup(2)
+  # u12 = calcProductGaussians(TranslationGroup(2) × SpecialOrthogonalGroup(2), [u1,u2], [bw1,bw2])
   u12 = calcProductGaussians(M, [u1,u2], [bw1,bw2])
 
   @test_broken isapprox( submanifold_component(mean(u12),1), submanifold_component(getPoints(p12)[sidx],1) )
@@ -78,20 +82,19 @@ end
 ## now check the marginal dimensions only
 
 # now do submanifold dimensions separately as reference test -- should get a similar result
-pts1_ = getPoints(p1_)
-pts2_ = getPoints(p2)
+pts1_ = getPoints(p1_SE2_marg_Tr2_kde)
+pts2_ = getPoints(p2_SE2_marg_Tr2_kde)
 
 ## Do the translation part separate
-@error "TODO use manellic tree belief instead, old MKD does not support LieGroups.jl.  Old MKD tree used coordinates."
 for sidx = 1:len
-  bw1 = getBW(p1_)[:,1] .^2
-  bw2 = getBW(p2)[:,1] .^2
+  bw1 = getBW(p1_SE2_marg_Tr2_kde)[:,1] .^2
+  bw2 = getBW(p2_SE2_marg_Tr2_kde)[:,1] .^2
 
   u1 = pts1_[selectedLabels[sidx][1]]
   u2 = pts2_[selectedLabels[sidx][2]]
 
   u12 = calcProductGaussians(TranslationGroup(2), [u1,u2], [bw1,bw2])
-  @test_broken isapprox( mean(u12), submanifold_component(M, getPoints(p12)[sidx], 1) )
+  @test isapprox( mean(u12), submanifold_component(M, getPoints(p12)[sidx], 1) )
 end
 
 
@@ -122,13 +125,17 @@ sidx = 1
 @error "TODO use manellic tree belief instead, old MKD does not support LieGroups.jl.  Old MKD tree used coordinates."
 for sidx = 1:len
 
-bw1 = getBW(p1)[:,1] .^2
-bw2 = getBW(p2, false)[:,1] .^2
+bw1 = getBW(p1_SE2_kde)[:,1] .^2
+bw2 = getBW(p2_SE2_marg_Tr2_kde, false)[:,1] .^2
 
 # full-partial points, but selected from partial-partial product
 u1 = pts1[selectedLabels__[sidx][1]]
 u2 = pts2[selectedLabels__[sidx][2]]
 
+# same as above
+  #FIXME - JT - I think this is comparing independent coordinates to a coupled SE(2) product
+  # Perhaps fix and test: TranslationGroup(2) × SpecialOrthogonalGroup(2)
+  # u12 = calcProductGaussians(TranslationGroup(2) × SpecialOrthogonalGroup(2), [u1,u2], [bw1,bw2])
 u12 = calcProductGaussians(M, [u1,u2], [bw1,bw2]);
 u12_ = calcProductGaussians(TranslationGroup(2), [submanifold_component(u1,1),submanifold_component(u2,1)], [bw1[1:2],bw2[1:2]]);
 
@@ -155,7 +162,7 @@ end
 # using Cairo, RoMEPlotting
 # Gadfly.set_default_plot_size(35cm,20cm)
 
-# n=10; plotKDE([p1_;p2; p12], levels=3, selectedPoints=selectedLabels[n:n])
+# n=10; plotKDE([p1_SE2_marg_Tr2_kde;p2_SE2_marg_Tr2_kde; p12], levels=3, selectedPoints=selectedLabels[n:n])
 # n=3; plotKDE([p1__;p2__; p12__], levels=3, selectedPoints=selectedLabels__[n:n])
 # plotKDE([p1__; p2__; p12__])
 

--- a/test/testSymmetry.jl
+++ b/test/testSymmetry.jl
@@ -14,18 +14,18 @@ a,b = randn(2), randn(2)
 @test isapprox( distance(M, a, b), distance(M, b, a), atol = 1e-5)
 
 
-M = SpecialOrthogonal(2)
+M = SpecialOrthogonalGroup(2)
 a,b = _Rot.RotMatrix(randn()), _Rot.RotMatrix(randn())
 @test isapprox( distance(M, a, b), distance(M, b, a), atol = 1e-5)
 
 
-M = SpecialEuclidean(2; vectors=HybridTangentRepresentation())
+M = SpecialEuclideanGroup(2; variant = :right)
 a = ArrayPartition(randn(2),_Rot.RotMatrix(randn()))
 b = ArrayPartition(randn(2),_Rot.RotMatrix(randn()))
 @test isapprox( distance(M, a, b), distance(M, b, a), atol = 1e-5)
 
 
-M = SpecialOrthogonal(3)
+M = SpecialOrthogonalGroup(3)
 a = _Rot.RotZ(randn())*_Rot.RotY(randn())*_Rot.RotX(randn())
 b = _Rot.RotZ(randn())*_Rot.RotY(randn())*_Rot.RotX(randn())
 @test isapprox( distance(M, a, b), distance(M, b, a), atol = 1e-5)


### PR DESCRIPTION
needs https://github.com/JuliaManifolds/LieGroups.jl/issues/57 resolved

Note:
`SpecialEuclidean(2; vectors=HybridTangentRepresentation())` will no longer be supported in Manifolds and LieGroups
- at identity `exp(base_manifold(G), ε, X)`  where G isa SpecialEuclideanGroup is equivalent.
- The coordinate based kde methods now uses `exp(base_manifold(G), ε, X)`  where G isa SpecialEuclideanGroup 
