### PR TITLE
simplify eigen truncSplitsort

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproxManifoldProducts"
 uuid = "9bbbb610-88a1-53cd-9763-118ce10c1f89"
 keywords = ["MM-iSAMv2", "SLAM", "inference", "sum-product", "belief-propagation", "nonparametric", "manifolds"]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/services/BuildHomotopyTree.jl
+++ b/src/services/BuildHomotopyTree.jl
@@ -278,10 +278,10 @@ function truncateOrSplitsort!(
         # NOTE, THIS USED TO BE AFTER recursive subtree build
         wei = sum(view(hode.weights, idxsubset))
         try
-            knl = ConcentratedGaussianKernel(
-                p, bw, wei; # TODO, try drop need for p here
-                partial, partl_cb
-            )
+            # knl = ConcentratedGaussianKernel(
+            #     p, bw, wei; # TODO, try drop need for p here
+            #     partial, partl_cb
+            # )
             # NEW, set majors_ fields here
             if length(hode.principal_coeffs) < index
                 resize!(hode.principal_coeffs, index)
@@ -289,8 +289,8 @@ function truncateOrSplitsort!(
                 resize!(hode.principal_forms, index)
             end
             hode.principal_coeffs[index] = sum(view(hode.weights, idxsubset))
-            hode.principal_elements[index] = mean(knl)
-            hode.principal_forms[index] = cov(knl)
+            hode.principal_elements[index] = p # mean(knl)
+            hode.principal_forms[index] = bw # cov(knl)
         catch e
             @error "DX bug stop, details:" string(bw) wei partial string(p)
             rethrow(e)


### PR DESCRIPTION
Allows `HomotopyDensity_legacy` object to be built with points and bw all zero.  This was done in legacy code, although it is a pathological case.  TBD if this should be supported in the future.